### PR TITLE
Add MVP scope prioritization guidance

### DIFF
--- a/docs/documentation_state_review.md
+++ b/docs/documentation_state_review.md
@@ -1,0 +1,24 @@
+# Documentation State Review and Improvement Spec
+
+## Objective
+Create a clear picture of the current documentation set, flag accuracy risks, and define actions to make the docs trustworthy and navigable.
+
+## Current Documentation Inventory
+- **README.md** – Still the default Vite template, no project-specific setup or environment guidance.【F:README.md†L1-L73】
+- **Project review** – High-level assessment with risks and recommendations, including Airtable credential exposure concerns.【F:docs/project_review.md†L3-L32】
+- **Architecture & structure** – Prescriptive folder layout and practices for a production-ready app, plus starter file lists for the MVP.【F:docs/project_architecture_structure.md†L1-L93】【F:docs/project_file_list.md†L1-L74】
+- **MVP walkthrough** – Describes features and claims verification (tsc/vite build, lint) without recorded commands or outputs.【F:docs/walkthrough.md†L1-L39】
+- **Planning specs** – Multiple scope-specific specs (scanner, product management, stock management) in `docs/specs/` detailing feature behaviors.
+
+## Findings & Gaps
+1) **Inaccurate landing doc** – README is generic Vite boilerplate; newcomers lack install, run, or environment setup steps.【F:README.md†L1-L73】
+2) **Unverified validation claims** – Walkthrough asserts successful build/lint with no traceable commands or CI status, risking drift from reality.【F:docs/walkthrough.md†L22-L25】
+3) **Fragmented planning** – Architecture, file lists, MVP plans, and walkthroughs live in separate docs without a canonical entry point or cross-links, making it hard to know which guidance to follow.【F:docs/project_architecture_structure.md†L1-L93】【F:docs/project_file_list.md†L1-L74】
+4) **Security guidance is isolated** – Airtable credential exposure and other risks are only captured in the project review; they are not surfaced in onboarding docs or operational checklists.【F:docs/project_review.md†L3-L32】
+
+## Recommendations
+- Replace the README with project-specific onboarding: prerequisites, install/run commands, environment variables, and a pointer to deeper docs.
+- Update the walkthrough to cite real test/build commands (or mark them pending) and link to where CI status will live.
+- Establish a single "Docs home" page that links to architecture, specs, review, and walkthrough; mark which documents are authoritative vs. experimental.
+- Create a lightweight "Operations & Safety" doc that brings forward Airtable/security warnings, environment variable handling, and testing expectations.
+- Version and review docs regularly (e.g., owner + last validated date) to keep guidance synchronized with the codebase.

--- a/docs/project_review.md
+++ b/docs/project_review.md
@@ -1,0 +1,32 @@
+# Project Review - Grocery Inventory App
+
+## Executive Summary
+- The app delivers a single-page barcode-to-inventory flow (scan → lookup → create or adjust stock) with polished UI styling, React Query caching, and PWA metadata already wired in Vite.
+- Critical risk: the Airtable API is called directly from the browser, meaning any deployed build would expose the secret API key and allow public modification of inventory data. A server-side proxy or backend service is required before production.
+- Core grocery scenarios are mostly scaffolded, but production readiness gaps remain around security, validation, resilience, and documentation/testing.
+
+## Architecture & Dependencies
+- React + Vite with React Query for data fetching and caching, Tailwind v4 for styling, and html5-qrcode for scanning. The QueryClient is provided at the app root for global caching.【F:src/main.tsx†L1-L14】【F:src/components/scanner/Scanner.tsx†L1-L74】
+- Airtable client is initialized in the frontend using Vite env vars and exported for use in the data-access layer. Table names are centralized.【F:src/lib/airtable.ts†L3-L20】
+- Data-access functions perform lookup, creation, and stock movement CRUD directly against Airtable, with optimistic stock updates handled in the ProductDetail component via React Query.【F:src/lib/api.ts†L4-L89】【F:src/components/product/ProductDetail.tsx†L11-L98】
+
+## Feature Coverage vs Specs
+- Barcode scanning: Camera-based scanning with supported formats and manual entry fallback are implemented; basic error overlay exists but no explicit permission-denied UX.【F:src/components/scanner/Scanner.tsx†L8-L69】【F:src/pages/ScanPage.tsx†L42-L82】
+- Product lookup & creation: A scanned/entered code triggers Airtable lookup; missing products show a create form with prefilled barcode, category/price/expiry inputs, and optional initial stock movement.【F:src/pages/ScanPage.tsx†L8-L71】【F:src/components/product/CreateProductForm.tsx†L1-L113】
+- Stock management: Product detail view displays core fields, current stock, recent movements, and +/- buttons that optimistically mutate stock and refetch history. Aligns with “Add/Remove” scenarios.【F:src/components/product/ProductDetail.tsx†L11-L138】
+- PWA: Manifest and assets are registered via vite-plugin-pwa with standalone display settings. Offline/response strategies are not configured yet.【F:vite.config.ts†L1-L38】
+
+## Risks & Gaps
+1) **Secret exposure & unrestricted writes** – Airtable API key and base ID are injected into the client bundle; all CRUD calls happen in-browser, enabling any user to read/write inventory data if the app ships. A backend proxy with row-level authorization is mandatory.【F:src/lib/airtable.ts†L3-L20】【F:src/lib/api.ts†L4-L89】
+2) **Formula injection surface** – `filterByFormula` interpolates unsanitized barcodes, allowing crafted codes to alter Airtable queries. Input should be sanitized/parameterized server-side.【F:src/lib/api.ts†L4-L21】
+3) **Error handling gaps** – Scanner silently swallows camera errors; product lookups only show a generic “Error connecting to DB”; stock mutations use `alert` for failures, leaving no durable UI state.【F:src/components/scanner/Scanner.tsx†L31-L69】【F:src/pages/ScanPage.tsx†L18-L69】【F:src/components/product/ProductDetail.tsx†L23-L63】
+4) **Validation & resilience** – Manual barcode entry allows any string length ≥4 with no format checks; Create form lacks guards for negative prices/stock; network/loading states are minimal outside the primary flow.【F:src/pages/ScanPage.tsx†L32-L72】【F:src/components/product/CreateProductForm.tsx†L12-L112】
+5) **Documentation & testing debt** – README remains the default Vite template and there are no automated tests or lint checks configured for CI; failed lint/test commands will be hard to trace.【F:README.md†L1-L52】
+
+## Recommendations (Priority-Ordered)
+1) Introduce a minimal backend proxy (e.g., serverless function) that handles Airtable auth, input sanitization, and role-based access; remove Airtable credentials from the client bundle.
+2) Add robust error/permission UX for the scanner (camera-denied state), network failures, and stock mutations; replace `alert` with inline toasts/banners.
+3) Harden input validation: barcode format checks (EAN/UPC), numeric validation for price/stock, and guardrails for expiry dates.
+4) Expand observability: structured logging around API calls, and React Query error boundaries to surface failures.
+5) Update README with setup/run steps, environment requirements, and known limitations; add lint/test scripts to CI once tooling is available.
+6) Extend PWA setup with service worker caching strategies for static assets and offline-friendly fallback screens.

--- a/docs/specs/backend_proxy.md
+++ b/docs/specs/backend_proxy.md
@@ -1,0 +1,27 @@
+# Backend Proxy for Airtable Security
+
+## Objective
+Move Airtable authentication and query logic from the browser to a trusted backend proxy to eliminate secret exposure, add authorization, and sanitize input before hitting Airtable.
+
+## Scope
+- Applies to all inventory CRUD operations currently implemented in `src/lib/api.ts` and any future Airtable access.
+
+## Requirements
+- Backend endpoint(s) handle read/write for products, stock movements, and product creation.
+- Airtable API key and base/table identifiers are stored server-side only (env vars); never shipped to the client bundle.
+- Input validation and sanitization for barcode, product data, and stock deltas before constructing Airtable formulas or payloads.
+- Role-based authorization surface (at minimum a single protected secret/token gate to start; extensible to per-user roles).
+- Centralized error handling that returns structured errors consumable by the React Query layer.
+
+## Implementation Notes
+- Recommended minimal approach: serverless functions (e.g., Vercel/Netlify) or an Express handler colocated with Vite.
+- Wrap Airtable access in server-side helpers; keep table names/constants centralized.
+- Provide an authenticated route for stock mutations and product creation; consider rate limiting on mutation routes.
+- Standardize response shape: `{ data, error, traceId }` for consistent client handling.
+- Add unit tests for sanitization helpers and integration smoke tests for each route.
+
+## Acceptance Criteria
+- No Airtable secret or base ID appears in the client build artifacts.
+- All frontend Airtable calls are replaced with calls to the backend proxy.
+- Barcode lookup path rejects malformed/injected formulas and logs the attempt server-side.
+- Documentation updated with environment variables and API surface for the proxy.

--- a/docs/specs/documentation_home.md
+++ b/docs/specs/documentation_home.md
@@ -1,0 +1,26 @@
+# Documentation Home and Onboarding Upgrade
+
+## Objective
+Provide a single, authoritative entry point for contributors with accurate setup, environment, and navigation guidance to reduce fragmentation.
+
+## Scope
+- README overhaul and a dedicated Docs Home index that links to architecture, specs, reviews, and walkthroughs.
+
+## Requirements
+- README includes prerequisites, install/run steps, environment variables (including Airtable proxy expectations), and known limitations.
+- Docs Home page enumerates all major documents with ownership and last-validated dates; marks authoritative vs. draft content.
+- Cross-links from existing specs/reviews back to Docs Home for discoverability, including the MVP scope/prioritization doc.
+- Walkthrough updated to reference real test/build commands or clearly mark pending steps.
+- Operational/Safety guidance (Airtable exposure, secrets handling, testing expectations) linked from onboarding.
+
+## Implementation Notes
+- Use concise tables for docs index (title, purpose, owner, last reviewed, authoritative/draft).
+- Add consistent front-matter or headings for date/owner fields to support future automation.
+- Keep README lean and point to Docs Home for deeper topics (architecture, flows, specs).
+
+## Acceptance Criteria
+- README no longer mirrors the Vite template and contains project-specific setup/run info.
+- A Docs Home page exists with links to all key documents and clearly labeled authority status.
+- Docs Home links to the MVP scope/prioritization document so contributors know which specs block launch.
+- Walkthrough includes actual commands (or TODO placeholders with owners) and references CI status location once available.
+- Security/operations notes are visible from the onboarding path.

--- a/docs/specs/mvp_scope.md
+++ b/docs/specs/mvp_scope.md
@@ -1,0 +1,24 @@
+# MVP Scope and Prioritization
+
+## Objective
+Clarify which open specs are mandatory to ship a safe, testable MVP versus which can be deferred to post-MVP hardening.
+
+## MVP-Critical (must ship)
+- **Backend proxy for Airtable** – Prevents credential leakage and enables server-side validation/sanitization for all Airtable calls.
+- **Validation guardrails** – Enforce barcode formats, non-negative stock/price, and basic expiry/date checks to avoid corrupting inventory data.
+- **Scanner/API error handling** – Provide user-visible errors (camera permissions, lookup failures, mutation failures) so core flows are recoverable.
+- **Operations & safety basics** – Document environment variables, secret handling, and rollback expectations so deployments are safe.
+
+## Nice-to-have for MVP (scope if time allows)
+- **Docs home/onboarding polish** – Helpful to reduce friction, but the MVP can launch with a lean README + links to the critical specs above.
+- **Observability hooks** – Lightweight logging/monitoring is useful but can be stubbed (client-side logs + simple server logs) and expanded post-MVP.
+- **PWA/offline behavior** – Optional for first release; prioritize online correctness before adding caching/offline flows.
+
+## Post-MVP hardening
+- Expand observability to include error budgets, tracing, and dashboards.
+- Add richer authorization beyond the initial shared secret/token for the backend proxy.
+- Invest in offline/PWA resilience (cache versioning, retry queues) once online flows are stable.
+
+## Acceptance
+- The MVP plan clearly communicates that only the "MVP-Critical" items block launch; other specs are scheduled for later iterations.
+- README/Docs Home (or equivalent entry point) links to this prioritization so contributors know what to implement first.

--- a/docs/specs/observability.md
+++ b/docs/specs/observability.md
@@ -1,0 +1,24 @@
+# Observability and Error Surfacing
+
+## Objective
+Improve visibility into API interactions, scanner behavior, and client errors to speed debugging and support production readiness.
+
+## Scope
+- Client logging/telemetry around Airtable proxy calls, scanner events, and React Query error boundaries.
+
+## Requirements
+- Structured logging for client-server interactions including correlation/trace IDs returned from the backend proxy.
+- React Query error boundaries or global handlers that surface failures with consistent UI copy.
+- Capture scanner errors (permission denied, camera init failure, decode errors) with context and timestamps.
+- Optional analytics hook to track mutation success/failure rates and retry counts.
+- Log redaction to avoid leaking sensitive payloads (e.g., API keys, PII).
+
+## Implementation Notes
+- Add a lightweight logging utility that can route to console in dev and a pluggable sink in production.
+- Consider integrating with browser Performance/Resource timing for slow API call detection.
+- Ensure logs include feature area and barcode/product identifiers where safe to do so.
+
+## Acceptance Criteria
+- Error events from scanner and API layers are recorded with correlation IDs and surfaced in UI.
+- Centralized logging utility is used instead of ad-hoc `console.log` for new code paths.
+- Observability is documented (what is logged, how to enable/disable, and where to view logs).

--- a/docs/specs/operations_safety.md
+++ b/docs/specs/operations_safety.md
@@ -1,0 +1,25 @@
+# Operations and Safety Guidance
+
+## Objective
+Document operational safeguards to prevent accidental data exposure, clarify secret handling, and align testing/monitoring expectations.
+
+## Scope
+- Deployment, secrets management, and runtime safety practices for the inventory app and its Airtable backend proxy.
+
+## Requirements
+- Secrets (Airtable, proxy tokens) are injected via environment variables and never committed or exposed to clients.
+- Clear deployment checklist: env var names, required tables/bases, and minimum auth controls before shipping.
+- Security notes surfaced to onboarding (link from README/Docs Home) with known risks and mitigations.
+- Testing expectations for releases: lint/build/tests to run and how to record results/CI status.
+- Incident/rollback guidance: how to disable client access or revoke keys if compromise is suspected.
+
+## Implementation Notes
+- Maintain a short runbook section covering rotate-key steps and Airtable permission adjustments.
+- Define logging expectations (structured logs with trace IDs) and retention location for backend proxy.
+- Provide example `.env.example` with placeholders and no secrets.
+
+## Acceptance Criteria
+- Documented checklist exists for deploying with secrets properly configured and verified.
+- Onboarding docs link to this safety guidance and highlight Airtable exposure risk if proxy is bypassed.
+- Release/test expectations are recorded and discoverable from README/Docs Home.
+- Runbook includes key rotation and emergency-disable steps.

--- a/docs/specs/pwa_offline.md
+++ b/docs/specs/pwa_offline.md
@@ -1,0 +1,25 @@
+# PWA Offline and Caching Strategy
+
+## Objective
+Extend the existing PWA setup with caching strategies that support offline resilience for the scanner flow and static assets.
+
+## Scope
+- Service worker configuration, asset caching, and offline UX for scan/create/update flows.
+
+## Requirements
+- Precache core static assets (HTML, JS, CSS, manifest, icons) with versioned cache naming.
+- Runtime caching strategy for API calls with graceful offline behavior (e.g., stale-while-revalidate for reads; queue mutations when offline if feasible).
+- Offline/low-connectivity UI that informs users when network is unavailable and what functionality is limited.
+- Clear cache busting approach on deployment to avoid serving stale manifests.
+- Monitoring hooks for service worker registration status and failures.
+
+## Implementation Notes
+- Evaluate Workbox or Vite PWA plugin options to add runtime caching rules and background sync (if permitted).
+- Provide feature flag or environment toggle to disable offline queuing if not desired initially.
+- Add manual “reset cache” option in a debug menu to assist with support issues.
+
+## Acceptance Criteria
+- Service worker caches core assets and provides an offline fallback page or message for the scan flow.
+- API read calls use a defined runtime caching strategy; mutations either queue or fail gracefully with instructions.
+- Offline/online transitions are detected and surfaced in the UI.
+- Deployment instructions include how to test and invalidate PWA caches.

--- a/docs/specs/scanner_error_handling.md
+++ b/docs/specs/scanner_error_handling.md
@@ -1,0 +1,26 @@
+# Scanner and API Error Experience
+
+## Objective
+Deliver resilient, user-friendly error handling for camera access, barcode scanning, network failures, and stock/product mutations.
+
+## Scope
+- Scanner component, scan page, and product detail/mutation flows.
+
+## Requirements
+- Explicit camera permission states: requesting, granted, denied (with recovery guidance and retry control).
+- Inline errors for lookup/mutation failures; replace `alert` usage with non-blocking toasts/banners.
+- Loading/empty/error states for product lookup and stock history; avoid silent failures.
+- Retry affordances for transient API errors (React Query retries with backoff where appropriate).
+- Telemetry hooks for scanner errors and API failures to aid debugging.
+
+## Implementation Notes
+- Surface camera-denied state with actionable steps (check browser permissions, open settings link if available).
+- Use React Query error boundaries or per-query `onError` handlers to centralize messaging.
+- Provide optimistic UI for stock mutations with rollback on failure and a clear error surface when rollback happens.
+- Co-locate error message copy for consistency and localization readiness.
+
+## Acceptance Criteria
+- No use of `alert` in scanner or product mutation flows.
+- Camera-denied state is visible and tested; manual entry remains available.
+- Users see clear, context-specific errors for lookup and stock mutations with retry guidance.
+- Telemetry/logging records scanner and API errors with correlation IDs or timestamps.

--- a/docs/specs/validation_guardrails.md
+++ b/docs/specs/validation_guardrails.md
@@ -1,0 +1,26 @@
+# Input Validation and Resilience Guardrails
+
+## Objective
+Harden user inputs and data integrity for barcode entry, pricing, stock adjustments, and expiry handling.
+
+## Scope
+- Manual barcode entry, product creation form, and stock adjustment inputs.
+
+## Requirements
+- Barcode validation: enforce UPC/EAN formats (length and character sets), reject malicious formula content, and normalize whitespace.
+- Pricing: non-negative numeric validation with currency formatting; optional upper bounds to catch obvious mistakes.
+- Stock adjustments: integer-only deltas; reject negative resulting inventory if business rules require non-negative stock.
+- Expiry and dates: validate date format, reject past dates when inappropriate, and display timezone assumptions.
+- Error copy is specific and inline; fields show validation state before submit when possible.
+
+## Implementation Notes
+- Centralize validation helpers for reuse across forms and backend proxy.
+- Normalize input on blur (trim, uppercase as needed) before validation to reduce false errors.
+- Pair client-side validation with server-side validation in the backend proxy for defense in depth.
+- Add form-level disable state during submission to prevent duplicate requests.
+
+## Acceptance Criteria
+- Manual barcode entry rejects malformed or unsafe values with clear messages and does not hit the API when invalid.
+- Create Product form blocks negative price/stock and invalid expiry dates with inline feedback.
+- Stock mutation buttons prevent invalid deltas and surface validation errors without API calls.
+- Shared validation utilities have unit test coverage for edge cases.


### PR DESCRIPTION
## Summary
- add an MVP scope/prioritization doc to distinguish critical launch blockers from optional hardening
- update docs home spec to cross-link the prioritization doc so contributors know what to implement first

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693306fd0ff083258bcd1aac0c56fae3)