### PR TITLE
Add Vue SFC versions of core pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/vue-query": "^5.90.12",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-icons": "^1.3.2",
@@ -24,6 +25,8 @@
     "clsx": "^2.1.1",
     "html5-qrcode": "^2.3.8",
     "i18next": "^25.7.2",
+    "vue": "^3.5.13",
+    "vue-i18n": "^9.14.2",
     "lucide-react": "^0.556.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/vue/components/product/ProductCreatePanel.vue
+++ b/src/vue/components/product/ProductCreatePanel.vue
@@ -1,0 +1,63 @@
+<template>
+  <CardPanel :title="t('product.newProduct')" :description="t('product.createFromScan')" :aria-label="t('product.newProduct')">
+    <form class="space-y-4" @submit.prevent="submit">
+      <BaseInput v-model="form.name" :label="t('product.name')" required />
+      <BaseInput v-model="form.category" :label="t('product.category')" />
+      <BaseInput v-model.number="form.price" :label="t('product.price')" type="number" step="0.01" />
+      <div class="flex items-center justify-end gap-2">
+        <BaseButton type="button" variant="ghost" @click="$emit('cancel')">{{ t('common.cancel') }}</BaseButton>
+        <BaseButton type="submit" :disabled="createMutation.isPending.value">{{ t('product.save') }}</BaseButton>
+      </div>
+    </form>
+  </CardPanel>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useMutation } from '@tanstack/vue-query';
+import { createProduct, type CreateProductDTO } from '../../lib/api';
+import BaseButton from '../ui/BaseButton.vue';
+import BaseInput from '../ui/BaseInput.vue';
+import CardPanel from '../ui/CardPanel.vue';
+import type { Product } from '../../types';
+import { useToast } from '../../composables/useToast';
+
+const props = defineProps<{ barcode: string }>();
+
+const emit = defineEmits<{ (e: 'created', product: Product): void; (e: 'cancel'): void }>();
+
+const { t } = useI18n();
+const { showToast } = useToast();
+
+const form = reactive({
+  name: '',
+  category: '',
+  price: undefined as number | undefined,
+});
+
+const createMutation = useMutation<Product, unknown, CreateProductDTO>({
+  mutationFn: async (payload) => createProduct(payload),
+  onSuccess: (product) => {
+    showToast('success', t('toast.productCreated'), t('toast.productCreatedMessage'));
+    form.name = '';
+    form.category = '';
+    form.price = undefined;
+    emit('created', product);
+  },
+  onError: (err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    showToast('error', t('toast.createFailed'), message);
+  },
+});
+
+const submit = () => {
+  const payload: CreateProductDTO = {
+    Name: form.name,
+    Barcode: props.barcode,
+    Category: form.category || undefined,
+    Price: form.price,
+  };
+  createMutation.mutate(payload);
+};
+</script>

--- a/src/vue/components/product/ProductSummary.vue
+++ b/src/vue/components/product/ProductSummary.vue
@@ -1,0 +1,34 @@
+<template>
+  <CardPanel :title="product.fields.Name" :description="product.fields.Category" :aria-label="product.fields.Name">
+    <div class="grid gap-2 text-sm text-stone-700">
+      <div class="flex items-center justify-between">
+        <span class="text-stone-500">{{ t('product.barcode') }}</span>
+        <span class="font-semibold">{{ product.fields.Barcode || t('scanner.manualEntry') }}</span>
+      </div>
+      <div class="flex items-center justify-between">
+        <span class="text-stone-500">{{ t('product.stock') }}</span>
+        <span class="font-semibold">{{ product.fields['Current Stock Level'] ?? 0 }}</span>
+      </div>
+      <div class="flex items-center justify-between">
+        <span class="text-stone-500">{{ t('product.price') }}</span>
+        <span class="font-semibold">€{{ (product.fields.Price ?? 0).toFixed(2) }}</span>
+      </div>
+    </div>
+    <div class="mt-4 flex justify-end">
+      <BaseButton variant="secondary" @click="$emit('reset')">{{ t('scanner.scanNew') }}</BaseButton>
+    </div>
+  </CardPanel>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import type { Product } from '../../types';
+import BaseButton from '../ui/BaseButton.vue';
+import CardPanel from '../ui/CardPanel.vue';
+
+defineProps<{ product: Product }>();
+
+defineEmits<{ (e: 'reset'): void }>();
+
+const { t } = useI18n();
+</script>

--- a/src/vue/components/scanner/ScannerFrame.vue
+++ b/src/vue/components/scanner/ScannerFrame.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="relative mx-auto w-full max-w-xl min-h-[280px]">
+    <div class="absolute inset-0 pointer-events-none z-10">
+      <div class="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-0.5 bg-stone-700 shadow-lg" aria-hidden="true" />
+    </div>
+    <div class="relative bg-black rounded-xl overflow-hidden border border-stone-700">
+      <div :id="regionId" class="w-full h-[280px]"></div>
+      <div
+        v-if="errorMessage"
+        class="absolute inset-0 flex items-center justify-center bg-red-50/90 border-4 border-red-500 text-red-900 p-4 text-center m-3 rounded-lg"
+        role="alert"
+      >
+        <p class="font-semibold text-sm">{{ errorMessage }}</p>
+      </div>
+    </div>
+    <p class="mt-2 text-center text-xs text-stone-500">{{ t('scanner.alignHint') || 'Align code within the frame' }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { Html5Qrcode, Html5QrcodeSupportedFormats } from 'html5-qrcode';
+import { useI18n } from 'vue-i18n';
+
+const props = withDefaults(defineProps<{ scannerId?: string }>(), { scannerId: 'vue-reader' });
+const emit = defineEmits<{ (e: 'scan', code: string): void }>();
+
+const { t } = useI18n();
+const scannerRef = ref<Html5Qrcode | null>(null);
+const errorMessage = ref<string | null>(null);
+const lastScan = ref<{ code: string; timestamp: number } | null>(null);
+const regionId = props.scannerId;
+
+const stopScanner = async () => {
+  if (scannerRef.value) {
+    try {
+      if (scannerRef.value.isScanning) {
+        await scannerRef.value.stop();
+      }
+      await scannerRef.value.clear();
+    } catch (err) {
+      console.error('Failed to stop scanner', err);
+    } finally {
+      scannerRef.value = null;
+    }
+  }
+};
+
+onMounted(async () => {
+  const formatsToSupport = [
+    Html5QrcodeSupportedFormats.UPC_A,
+    Html5QrcodeSupportedFormats.UPC_E,
+    Html5QrcodeSupportedFormats.EAN_13,
+    Html5QrcodeSupportedFormats.EAN_8,
+    Html5QrcodeSupportedFormats.QR_CODE,
+  ];
+
+  try {
+    const scanner = new Html5Qrcode(regionId);
+    scannerRef.value = scanner;
+
+    await scanner.start(
+      { facingMode: 'environment' },
+      {
+        formatsToSupport,
+        fps: 24,
+        qrbox: { width: 240, height: 240 },
+      },
+      (decodedText) => {
+        const clean = decodedText.trim();
+        const validLengths = [8, 12, 13];
+        if (!validLengths.includes(clean.length)) return;
+        const now = Date.now();
+        if (lastScan.value && lastScan.value.code === clean && now - lastScan.value.timestamp < 1500) return;
+        lastScan.value = { code: clean, timestamp: now };
+        emit('scan', clean);
+      },
+      (err) => {
+        const expected =
+          err.includes('No MultiFormat Readers') ||
+          err.includes('NotFoundException') ||
+          err.includes('No barcode or QR code detected');
+        if (!expected) {
+          errorMessage.value = err;
+        }
+      }
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    errorMessage.value = message;
+  }
+});
+
+onBeforeUnmount(stopScanner);
+
+watch(
+  () => props.scannerId,
+  async () => {
+    await stopScanner();
+  }
+);
+</script>

--- a/src/vue/components/ui/BaseButton.vue
+++ b/src/vue/components/ui/BaseButton.vue
@@ -1,0 +1,45 @@
+<template>
+  <button
+    :type="type"
+    :disabled="disabled"
+    :class="classes"
+    v-bind="$attrs"
+  >
+    <span class="flex items-center gap-2 justify-center">
+      <slot />
+    </span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    type?: 'button' | 'submit' | 'reset';
+    variant?: 'primary' | 'secondary' | 'ghost';
+    fullWidth?: boolean;
+    disabled?: boolean;
+  }>(),
+  {
+    type: 'button',
+    variant: 'primary',
+    fullWidth: false,
+    disabled: false,
+  }
+);
+
+const classes = computed(() => {
+  const base =
+    'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2';
+  const variant =
+    props.variant === 'secondary'
+      ? 'bg-white border border-stone-300 text-stone-800 hover:bg-stone-50 focus-visible:outline-stone-900'
+      : props.variant === 'ghost'
+        ? 'bg-transparent text-stone-700 hover:bg-stone-100 focus-visible:outline-stone-900'
+        : 'bg-stone-900 text-white hover:bg-stone-800 focus-visible:outline-stone-900 shadow-sm';
+  const disabled = props.disabled ? 'opacity-60 cursor-not-allowed' : '';
+  const width = props.fullWidth ? 'w-full' : '';
+  return [base, variant, disabled, width].join(' ');
+});
+</script>

--- a/src/vue/components/ui/BaseInput.vue
+++ b/src/vue/components/ui/BaseInput.vue
@@ -1,0 +1,31 @@
+<template>
+  <label class="flex flex-col gap-1 text-sm text-stone-700">
+    <span v-if="label" class="font-semibold">{{ label }}</span>
+    <input
+      v-bind="$attrs"
+      :type="type"
+      :value="modelValue"
+      :placeholder="placeholder"
+      class="h-11 rounded-lg border border-stone-300 bg-white px-3 py-2 text-stone-900 placeholder:text-stone-400 focus:border-stone-900 focus:ring-2 focus:ring-stone-900/15"
+      @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    />
+  </label>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    modelValue: string | number;
+    label?: string;
+    placeholder?: string;
+    type?: string;
+  }>(),
+  {
+    type: 'text',
+  }
+);
+
+defineEmits<{
+  (e: 'update:modelValue', value: string | number): void;
+}>();
+</script>

--- a/src/vue/components/ui/CardPanel.vue
+++ b/src/vue/components/ui/CardPanel.vue
@@ -1,0 +1,30 @@
+<template>
+  <section
+    class="rounded-2xl border border-stone-200 bg-white shadow-sm"
+    role="region"
+    :aria-label="ariaLabel"
+  >
+    <header v-if="title || description" class="border-b border-stone-100 px-4 py-3">
+      <p v-if="eyebrow" class="text-[11px] uppercase tracking-widest text-stone-400 font-semibold">{{ eyebrow }}</p>
+      <div class="flex items-start justify-between gap-2">
+        <div class="space-y-1">
+          <h2 class="text-lg font-semibold text-stone-900">{{ title }}</h2>
+          <p v-if="description" class="text-sm text-stone-500">{{ description }}</p>
+        </div>
+        <slot name="actions" />
+      </div>
+    </header>
+    <div class="p-4">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  title?: string;
+  description?: string;
+  eyebrow?: string;
+  ariaLabel?: string;
+}>();
+</script>

--- a/src/vue/components/ui/EmptyState.vue
+++ b/src/vue/components/ui/EmptyState.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="flex flex-col items-center justify-center text-center text-stone-500 gap-2 py-8">
+    <div class="h-12 w-12 rounded-full bg-stone-100 text-stone-400 flex items-center justify-center text-xl" aria-hidden="true">
+      <slot name="icon">🛈</slot>
+    </div>
+    <p class="text-sm font-medium">{{ title }}</p>
+    <p v-if="description" class="text-sm text-stone-400 max-w-md">{{ description }}</p>
+    <div v-if="$slots.actions" class="mt-3"><slot name="actions" /></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ title: string; description?: string }>();
+</script>

--- a/src/vue/components/ui/PageHeader.vue
+++ b/src/vue/components/ui/PageHeader.vue
@@ -1,0 +1,28 @@
+<template>
+  <header class="flex items-center gap-3 pb-4">
+    <BaseButton variant="ghost" class="h-10 w-10" :aria-label="t('common.back')" @click="$emit('back')">
+      ←
+    </BaseButton>
+    <div class="flex-1 min-w-0">
+      <p v-if="eyebrow" class="text-[11px] uppercase tracking-[0.2em] text-stone-400 font-semibold">{{ eyebrow }}</p>
+      <h1 class="text-2xl font-semibold text-stone-900 truncate">{{ title }}</h1>
+      <p v-if="description" class="text-sm text-stone-500">{{ description }}</p>
+    </div>
+    <slot name="actions" />
+  </header>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import BaseButton from './BaseButton.vue';
+
+defineProps<{
+  title: string;
+  description?: string;
+  eyebrow?: string;
+}>();
+
+defineEmits<{ (e: 'back'): void }>();
+
+const { t } = useI18n();
+</script>

--- a/src/vue/components/ui/SkeletonBlock.vue
+++ b/src/vue/components/ui/SkeletonBlock.vue
@@ -1,0 +1,15 @@
+<template>
+  <div :class="['animate-pulse rounded-lg bg-stone-200', heightClass]" role="presentation"></div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(defineProps<{ height?: 'sm' | 'md' | 'lg' }>(), { height: 'md' });
+
+const heightClass = computed(() => {
+  if (props.height === 'sm') return 'h-6';
+  if (props.height === 'lg') return 'h-24';
+  return 'h-10';
+});
+</script>

--- a/src/vue/components/ui/ToastHost.vue
+++ b/src/vue/components/ui/ToastHost.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="fixed top-4 inset-x-0 flex flex-col gap-3 items-center pointer-events-none z-[2000]">
+    <div
+      v-for="toast in toasts"
+      :key="toast.id"
+      class="pointer-events-auto w-[320px] rounded-xl shadow-lg border bg-white/90 backdrop-blur px-4 py-3"
+      role="status"
+      :aria-label="toast.title"
+    >
+      <div class="flex items-start gap-3">
+        <span
+          class="mt-1 h-2 w-2 rounded-full"
+          :class="toast.variant === 'success' ? 'bg-emerald-500' : toast.variant === 'error' ? 'bg-rose-500' : 'bg-stone-400'"
+        ></span>
+        <div class="flex-1 space-y-1">
+          <p class="text-sm font-semibold text-stone-900">{{ toast.title }}</p>
+          <p v-if="toast.description" class="text-xs text-stone-600">{{ toast.description }}</p>
+        </div>
+        <button
+          type="button"
+          class="text-stone-400 hover:text-stone-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stone-900 rounded"
+          @click="removeToast(toast.id)"
+          :aria-label="t('common.close')"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { useToast } from '../../composables/useToast';
+
+const { t } = useI18n();
+const { toasts, removeToast } = useToast();
+</script>

--- a/src/vue/composables/useToast.ts
+++ b/src/vue/composables/useToast.ts
@@ -1,0 +1,40 @@
+import { computed, ref } from 'vue';
+
+export type ToastVariant = 'success' | 'error' | 'info';
+
+export interface ToastItem {
+  id: number;
+  variant: ToastVariant;
+  title: string;
+  description?: string;
+  duration?: number;
+}
+
+const toasts = ref<ToastItem[]>([]);
+let counter = 0;
+
+export const useToast = () => {
+  const removeToast = (id: number) => {
+    toasts.value = toasts.value.filter((toast) => toast.id !== id);
+  };
+
+  const showToast = (
+    variant: ToastVariant,
+    title: string,
+    description?: string,
+    duration = 3200
+  ) => {
+    const id = ++counter;
+    toasts.value.push({ id, variant, title, description, duration });
+
+    if (duration > 0) {
+      setTimeout(() => removeToast(id), duration);
+    }
+  };
+
+  return {
+    toasts: computed(() => toasts.value),
+    showToast,
+    removeToast,
+  };
+};

--- a/src/vue/i18n.ts
+++ b/src/vue/i18n.ts
@@ -1,0 +1,14 @@
+import { createI18n } from 'vue-i18n';
+import en from '../locales/en.json';
+import es from '../locales/es.json';
+import ro from '../locales/ro.json';
+import ru from '../locales/ru.json';
+
+export const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en, es, ro, ru },
+});
+
+export default i18n;

--- a/src/vue/pages/CheckoutPage.vue
+++ b/src/vue/pages/CheckoutPage.vue
@@ -1,0 +1,200 @@
+<template>
+  <div class="min-h-screen bg-gradient-to-br from-stone-100 to-stone-200 p-4 lg:p-8">
+    <PageHeader
+      :title="t('home.checkoutMode.title')"
+      :description="t('home.checkoutMode.description')"
+      :eyebrow="t('home.checkoutMode.badgeTablet')"
+      @back="emit('back')"
+    />
+    <div class="grid gap-6 lg:grid-cols-[1.1fr_1fr]">
+      <CardPanel :title="t('scanner.title')" :description="t('scanner.subtitle')" aria-label="checkout scanner">
+        <div class="space-y-4">
+          <ScannerFrame scanner-id="vue-checkout" @scan="handleScan" />
+          <form class="flex gap-2" @submit.prevent="handleManualSubmit">
+            <BaseInput v-model="manualCode" :placeholder="t('scanner.manualEntry')" class="flex-1" />
+            <BaseButton type="submit" :disabled="manualCode.trim().length < 3">{{ t('scanner.addButton') }}</BaseButton>
+          </form>
+        </div>
+      </CardPanel>
+
+      <CardPanel :title="t('cart.title')" :description="t('cart.subtitle')" aria-label="cart">
+        <div class="flex flex-col gap-3">
+          <div class="flex items-center justify-between text-sm text-stone-600">
+            <span>{{ t('cart.items', { count: itemCount }) }}</span>
+            <span class="font-semibold text-stone-900">€{{ total.toFixed(2) }}</span>
+          </div>
+
+          <div v-if="lookupQuery.isFetching.value" class="p-3 border rounded-lg border-stone-200 bg-stone-50">
+            {{ t('loading.checkout') }}
+          </div>
+          <div v-if="lookupQuery.error.value" class="p-3 border rounded-lg border-rose-100 text-rose-700 text-sm">
+            {{ t('toast.lookupFailed') }}
+          </div>
+
+          <ul class="divide-y divide-stone-100" aria-live="polite">
+            <li v-for="(item, index) in cart" :key="item.product.id" class="py-3 flex items-start gap-3">
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-stone-900">{{ item.product.fields.Name }}</p>
+                <p class="text-xs text-stone-500">{{ item.product.fields.Barcode }}</p>
+                <p class="text-xs text-stone-500">
+                  {{ t('product.stock') }}: {{ item.product.fields['Current Stock Level'] ?? 0 }} ·
+                  {{ t('product.price') }} €{{ (item.product.fields.Price ?? 0).toFixed(2) }}
+                </p>
+                <p v-if="item.status" class="text-xs text-rose-600">{{ item.status }}</p>
+              </div>
+              <div class="flex items-center gap-2">
+                <BaseButton variant="ghost" class="h-9 w-9" @click="updateQuantity(index, -1)">−</BaseButton>
+                <span class="w-8 text-center font-semibold">{{ item.quantity }}</span>
+                <BaseButton variant="ghost" class="h-9 w-9" @click="updateQuantity(index, 1)">+</BaseButton>
+              </div>
+            </li>
+          </ul>
+
+          <EmptyState
+            v-if="cart.length === 0"
+            :title="t('cart.empty')"
+            :description="t('scanner.startHint')"
+          >
+            <template #icon>🛒</template>
+          </EmptyState>
+
+          <div class="flex items-center justify-end gap-3">
+            <BaseButton variant="ghost" @click="resetCart" :disabled="cart.length === 0">{{ t('cart.clear') }}</BaseButton>
+            <BaseButton
+              :disabled="cart.length === 0 || checkoutMutation.isPending.value"
+              @click="checkout"
+            >
+              {{ checkoutMutation.isPending.value ? t('loading.checkout') : t('cart.checkout') }}
+            </BaseButton>
+          </div>
+        </div>
+      </CardPanel>
+    </div>
+    <ToastHost />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useMutation, useQuery } from '@tanstack/vue-query';
+import { addStockMovement, getProductByBarcode } from '../../lib/api';
+import type { Product } from '../../types';
+import PageHeader from '../components/ui/PageHeader.vue';
+import CardPanel from '../components/ui/CardPanel.vue';
+import BaseButton from '../components/ui/BaseButton.vue';
+import BaseInput from '../components/ui/BaseInput.vue';
+import EmptyState from '../components/ui/EmptyState.vue';
+import ScannerFrame from '../components/scanner/ScannerFrame.vue';
+import ToastHost from '../components/ui/ToastHost.vue';
+import { useToast } from '../composables/useToast';
+
+const emit = defineEmits<{ (e: 'back'): void }>();
+const { t } = useI18n();
+const { showToast } = useToast();
+
+interface CartEntry {
+  product: Product;
+  quantity: number;
+  status?: string;
+}
+
+const cart = ref<CartEntry[]>([]);
+const scannedCode = ref<string | null>(null);
+const manualCode = ref('');
+
+const lookupQuery = useQuery({
+  queryKey: computed(() => ['vue', 'checkout', scannedCode.value]),
+  queryFn: () => getProductByBarcode(scannedCode.value || ''),
+  enabled: computed(() => Boolean(scannedCode.value)),
+  retry: 0,
+});
+
+watch(
+  () => lookupQuery.data.value,
+  (product) => {
+    if (product) {
+      addItem(product);
+      scannedCode.value = null;
+    }
+  }
+);
+
+const itemCount = computed(() => cart.value.reduce((sum, item) => sum + item.quantity, 0));
+const total = computed(() =>
+  cart.value.reduce((sum, item) => sum + (item.product.fields.Price ?? 0) * item.quantity, 0)
+);
+
+const handleScan = (code: string) => {
+  scannedCode.value = code;
+  manualCode.value = code;
+};
+
+const handleManualSubmit = () => {
+  if (manualCode.value.trim().length >= 3) {
+    scannedCode.value = manualCode.value.trim();
+  }
+};
+
+const addItem = (product: Product) => {
+  const available = product.fields['Current Stock Level'] ?? 0;
+  if (available < 1) {
+    showToast('error', t('product.insufficientStock'), t('cart.noStock'));
+    return;
+  }
+
+  const existingIndex = cart.value.findIndex((entry) => entry.product.id === product.id);
+  if (existingIndex >= 0) {
+    const entry = cart.value[existingIndex];
+    if (entry.quantity + 1 > available) {
+      cart.value[existingIndex] = { ...entry, status: t('product.insufficientStock') };
+      return;
+    }
+    cart.value[existingIndex] = { ...entry, quantity: entry.quantity + 1, status: undefined };
+  } else {
+    cart.value.push({ product, quantity: 1 });
+  }
+  showToast('success', t('toast.addedToCart'), product.fields.Name);
+};
+
+const updateQuantity = (index: number, delta: number) => {
+  const entry = cart.value[index];
+  if (!entry) return;
+  const available = entry.product.fields['Current Stock Level'] ?? 0;
+  const newQuantity = entry.quantity + delta;
+  if (newQuantity <= 0) {
+    cart.value.splice(index, 1);
+    return;
+  }
+  if (delta > 0 && newQuantity > available) {
+    cart.value[index] = { ...entry, status: t('product.insufficientStock') };
+    return;
+  }
+  cart.value[index] = { ...entry, quantity: newQuantity, status: undefined };
+};
+
+const checkoutMutation = useMutation({
+  mutationFn: async () => {
+    for (const entry of cart.value) {
+      await addStockMovement(entry.product.id, entry.quantity, 'OUT');
+    }
+  },
+  onSuccess: () => {
+    showToast('success', t('toast.checkoutComplete'), t('toast.checkoutCompleteMessage'));
+    cart.value = [];
+  },
+  onError: (err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    showToast('error', t('toast.updateFailed'), message);
+  },
+});
+
+const checkout = () => {
+  if (cart.value.length === 0) return;
+  checkoutMutation.mutate();
+};
+
+const resetCart = () => {
+  cart.value = [];
+};
+</script>

--- a/src/vue/pages/InventoryListPage.vue
+++ b/src/vue/pages/InventoryListPage.vue
@@ -1,0 +1,155 @@
+<template>
+  <div class="min-h-screen bg-gradient-to-br from-stone-100 to-stone-200 p-4 lg:p-8">
+    <PageHeader
+      :title="t('home.viewInventory.title')"
+      :description="t('home.viewInventory.description')"
+      :eyebrow="t('home.viewInventory.badge')"
+      @back="emit('back')"
+    />
+
+    <div class="grid gap-4 lg:grid-cols-[320px_1fr]">
+      <CardPanel :title="t('inventory.filters')" :description="t('inventory.quickSearch')" aria-label="filters">
+        <div class="space-y-3">
+          <BaseInput v-model="search" :placeholder="t('inventory.searchPlaceholder')" />
+          <p class="text-xs text-stone-500">{{ t('inventory.total', { count: products.value?.length || 0 }) }}</p>
+        </div>
+      </CardPanel>
+
+      <CardPanel :title="t('inventory.listTitle')" :description="t('inventory.listSubtitle')" aria-label="inventory list">
+        <div v-if="query.isFetching.value" class="space-y-3">
+          <SkeletonBlock height="lg" />
+          <SkeletonBlock height="lg" />
+        </div>
+        <div v-else>
+          <div class="overflow-x-auto">
+            <table class="min-w-full text-left text-sm">
+              <thead class="text-xs uppercase tracking-wide text-stone-500">
+                <tr>
+                  <th class="py-2 pr-2">{{ t('product.name') }}</th>
+                  <th class="py-2 pr-2">{{ t('product.category') }}</th>
+                  <th class="py-2 pr-2">{{ t('product.stock') }}</th>
+                  <th class="py-2 pr-2">{{ t('product.price') }}</th>
+                  <th class="py-2 pr-2 text-right">{{ t('inventory.actions') }}</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-stone-100">
+                <tr v-for="product in filtered" :key="product.id" class="align-middle">
+                  <td class="py-3 pr-2 font-semibold text-stone-900">{{ product.fields.Name }}</td>
+                  <td class="py-3 pr-2 text-stone-600">{{ product.fields.Category || '—' }}</td>
+                  <td class="py-3 pr-2 text-stone-800">
+                    {{ product.fields['Current Stock Level'] ?? 0 }}
+                    <span v-if="product.fields['Min Stock Level'] != null" class="text-xs text-stone-500">
+                      / {{ product.fields['Min Stock Level'] }}
+                    </span>
+                  </td>
+                  <td class="py-3 pr-2 text-stone-800">€{{ (product.fields.Price ?? 0).toFixed(2) }}</td>
+                  <td class="py-3 pr-2 text-right">
+                    <div class="inline-flex items-center gap-2">
+                      <BaseButton
+                        variant="secondary"
+                        class="h-8 px-3"
+                        :disabled="adjustMutation.isPending.value"
+                        @click="quickAdjust(product, 1)"
+                      >
+                        {{ t('inventory.addOne') }}
+                      </BaseButton>
+                      <BaseButton
+                        variant="ghost"
+                        class="h-8 px-3"
+                        :disabled="adjustMutation.isPending.value"
+                        @click="quickAdjust(product, -1)"
+                      >
+                        {{ t('inventory.removeOne') }}
+                      </BaseButton>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <EmptyState
+            v-if="!filtered.length && !query.isFetching.value"
+            :title="t('inventory.noResults')"
+            :description="t('inventory.tryFilters')"
+          />
+        </div>
+      </CardPanel>
+    </div>
+    <ToastHost />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query';
+import { addStockMovement, getAllProducts } from '../../lib/api';
+import type { Product } from '../../types';
+import PageHeader from '../components/ui/PageHeader.vue';
+import CardPanel from '../components/ui/CardPanel.vue';
+import BaseInput from '../components/ui/BaseInput.vue';
+import BaseButton from '../components/ui/BaseButton.vue';
+import SkeletonBlock from '../components/ui/SkeletonBlock.vue';
+import EmptyState from '../components/ui/EmptyState.vue';
+import ToastHost from '../components/ui/ToastHost.vue';
+import { useToast } from '../composables/useToast';
+
+const emit = defineEmits<{ (e: 'back'): void }>();
+const { t } = useI18n();
+const { showToast } = useToast();
+const queryClient = useQueryClient();
+
+const search = ref('');
+
+const query = useQuery({
+  queryKey: ['vue', 'inventory', 'all'],
+  queryFn: () => getAllProducts(),
+});
+
+const products = computed(() => query.data.value || []);
+const filtered = computed(() => {
+  const term = search.value.toLowerCase();
+  if (!term) return products.value;
+  return products.value.filter((product) =>
+    product.fields.Name.toLowerCase().includes(term) ||
+    (product.fields.Barcode && product.fields.Barcode.toLowerCase().includes(term))
+  );
+});
+
+const adjustMutation = useMutation({
+  mutationFn: async ({ product, delta }: { product: Product; delta: number }) => {
+    const type = delta > 0 ? 'IN' : 'OUT';
+    const quantity = Math.abs(delta);
+    await addStockMovement(product.id, quantity, type);
+    queryClient.setQueryData<Product[]>(['vue', 'inventory', 'all'], (current = []) =>
+      current.map((p) =>
+        p.id === product.id
+          ? {
+              ...p,
+              fields: {
+                ...p.fields,
+                'Current Stock Level': (p.fields['Current Stock Level'] ?? 0) + delta,
+              },
+            }
+          : p
+      )
+    );
+  },
+  onSuccess: () => {
+    showToast('success', t('toast.stockUpdated'), t('toast.stockUpdatedMessage'));
+  },
+  onError: (err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    showToast('error', t('toast.updateFailed'), message);
+  },
+});
+
+const quickAdjust = (product: Product, delta: number) => {
+  const current = product.fields['Current Stock Level'] ?? 0;
+  if (delta < 0 && current + delta < 0) {
+    showToast('error', t('product.insufficientStock'), t('product.cannotRemove'));
+    return;
+  }
+  adjustMutation.mutate({ product, delta });
+};
+</script>

--- a/src/vue/pages/ScanPage.vue
+++ b/src/vue/pages/ScanPage.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="min-h-screen bg-gradient-to-br from-stone-100 to-stone-200 p-4 lg:p-8">
+    <PageHeader :title="headerTitle" :description="t('scanner.helper')" @back="emit('back')" />
+    <div class="grid gap-6 lg:grid-cols-2">
+      <CardPanel :title="t('scanner.title')" :description="t('scanner.subtitle')" aria-label="scanner">
+        <div class="space-y-4">
+          <ScannerFrame scanner-id="vue-scan" @scan="handleScan" />
+          <form class="flex gap-2" @submit.prevent="handleManualSubmit">
+            <BaseInput v-model="manualCode" :placeholder="t('scanner.manualEntry')" class="flex-1" />
+            <BaseButton type="submit" :disabled="manualCode.trim().length < 3">{{ t('scanner.addButton') }}</BaseButton>
+          </form>
+        </div>
+      </CardPanel>
+
+      <CardPanel
+        :title="panelTitle"
+        :description="panelSubtitle"
+        aria-label="scan results"
+      >
+        <SkeletonBlock v-if="productQuery.isFetching.value" height="lg" />
+        <ProductSummary
+          v-else-if="productQuery.data.value && scannedCode"
+          :product="productQuery.data.value"
+          @reset="resetScan"
+        />
+        <ProductCreatePanel
+          v-else-if="scannedCode"
+          :barcode="scannedCode"
+          @created="resetScan"
+          @cancel="resetScan"
+        />
+        <EmptyState
+          v-else
+          :title="t('scanner.emptyState')"
+          :description="t('scanner.startHint')"
+        />
+      </CardPanel>
+    </div>
+    <ToastHost />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useQuery } from '@tanstack/vue-query';
+import { getProductByBarcode } from '../../lib/api';
+import PageHeader from '../components/ui/PageHeader.vue';
+import CardPanel from '../components/ui/CardPanel.vue';
+import BaseButton from '../components/ui/BaseButton.vue';
+import BaseInput from '../components/ui/BaseInput.vue';
+import ProductSummary from '../components/product/ProductSummary.vue';
+import ProductCreatePanel from '../components/product/ProductCreatePanel.vue';
+import EmptyState from '../components/ui/EmptyState.vue';
+import SkeletonBlock from '../components/ui/SkeletonBlock.vue';
+import ScannerFrame from '../components/scanner/ScannerFrame.vue';
+import ToastHost from '../components/ui/ToastHost.vue';
+import { useToast } from '../composables/useToast';
+
+const emit = defineEmits<{ (e: 'back'): void }>();
+
+const { t } = useI18n();
+const { showToast } = useToast();
+const scannedCode = ref<string | null>(null);
+const manualCode = ref('');
+
+const productQuery = useQuery({
+  queryKey: computed(() => ['vue', 'scan', scannedCode.value]),
+  queryFn: () => getProductByBarcode(scannedCode.value || ''),
+  enabled: computed(() => Boolean(scannedCode.value)),
+  retry: 0,
+});
+
+const headerTitle = computed(() =>
+  scannedCode.value
+    ? productQuery.data.value
+      ? t('product.manageStock')
+      : t('product.newProduct')
+    : t('scanner.title')
+);
+
+const panelTitle = computed(() =>
+  productQuery.data.value
+    ? productQuery.data.value.fields.Name
+    : scannedCode.value
+      ? t('product.newProduct')
+      : t('scanner.awaitingScan')
+);
+
+const panelSubtitle = computed(() => {
+  if (productQuery.isFetching.value) return t('loading.scanner');
+  if (productQuery.error.value) return t('toast.lookupFailed');
+  if (productQuery.data.value) return t('product.manageStock');
+  if (scannedCode.value) return t('product.createFromScan');
+  return t('scanner.startHint');
+});
+
+watch(
+  () => productQuery.error.value,
+  (err) => {
+    if (err && scannedCode.value) {
+      const message = err instanceof Error ? err.message : String(err);
+      showToast('error', t('toast.lookupFailed'), message);
+    }
+  }
+);
+
+const handleScan = (code: string) => {
+  scannedCode.value = code;
+  manualCode.value = code;
+  if (navigator.vibrate) navigator.vibrate(160);
+};
+
+const handleManualSubmit = () => {
+  if (manualCode.value.trim().length >= 3) {
+    handleScan(manualCode.value.trim());
+  }
+};
+
+const resetScan = () => {
+  scannedCode.value = null;
+  manualCode.value = '';
+};
+</script>

--- a/src/vue/pages/index.ts
+++ b/src/vue/pages/index.ts
@@ -1,0 +1,3 @@
+export { default as VueScanPage } from './ScanPage.vue';
+export { default as VueCheckoutPage } from './CheckoutPage.vue';
+export { default as VueInventoryListPage } from './InventoryListPage.vue';

--- a/src/vue/queryClient.ts
+++ b/src/vue/queryClient.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from '@tanstack/vue-query';
+
+export const vueQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 30_000,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export default vueQueryClient;


### PR DESCRIPTION
## Summary
- add Vue dependencies plus shared i18n/query client setup for the Vue surface
- introduce Vue UI primitives, scanner frame, and toast composable as Radix-free building blocks
- implement Composition API SFC versions of Scan, Checkout, and Inventory pages using Vue Query and existing Airtable APIs

## Testing
- pnpm install --lockfile-only *(fails: registry returned 403 for @types/react)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c62b8175c83258fd9b86efcef34a3)