### PR TITLE
Rename environment variables to Nuxt prefixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,18 @@
 # Airtable Configuration (TEMPORARY - will be moved to backend proxy)
 # Personal access token with read/write access to the Inventory base
-VITE_AIRTABLE_API_KEY=your_airtable_personal_token_here
+NUXT_PUBLIC_AIRTABLE_API_KEY=your_airtable_personal_token_here
 
 # The Airtable Base ID for the Inventory workspace
-VITE_AIRTABLE_BASE_ID=appXXXXXXXXXXXXXX
+NUXT_PUBLIC_AIRTABLE_BASE_ID=appXXXXXXXXXXXXXX
 
 # Backend Proxy (when implemented - see docs/specs/backend_proxy.md)
 # Uncomment and point to the proxy once available to avoid exposing Airtable tokens in the client
-# VITE_BACKEND_PROXY_URL=http://localhost:3001
-# VITE_PROXY_AUTH_TOKEN=your_secure_token_here
+# NUXT_PUBLIC_BACKEND_PROXY_URL=http://localhost:3001
+# NUXT_PROXY_AUTH_TOKEN=your_secure_token_here
 
 # Image Upload (for camera capture feature)
 # Development: Get a free API key at https://api.imgbb.com/
-VITE_IMGBB_API_KEY=your_imgbb_api_key_here
+NUXT_PUBLIC_IMGBB_API_KEY=your_imgbb_api_key_here
 
 # Production (Vercel): Image upload uses Vercel Blob storage
 # Add BLOB_READ_WRITE_TOKEN in Vercel dashboard → Settings → Environment Variables

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,13 +131,13 @@ Production (Vercel):
 
 Development (Local):
   └── Falls back to imgbb.com (free image hosting)
-  └── Add VITE_IMGBB_API_KEY to .env
+  └── Add NUXT_PUBLIC_IMGBB_API_KEY to .env
 ```
 
 **Environment Variables**:
 ```bash
 # Development: imgbb fallback
-VITE_IMGBB_API_KEY=your_api_key_here  # Get free key at https://api.imgbb.com/
+NUXT_PUBLIC_IMGBB_API_KEY=your_api_key_here  # Get free key at https://api.imgbb.com/
 
 # Production: Vercel Blob (set in Vercel dashboard)
 BLOB_READ_WRITE_TOKEN=vercel_blob_rw_xxxxx
@@ -249,12 +249,12 @@ To implement barcode scanning (from `docs/specs/scanner.md`):
 ## Security & Environment
 
 ### Required Environment Variables
-- `VITE_AIRTABLE_API_KEY`: Airtable personal access token (read/write)
-- `VITE_AIRTABLE_BASE_ID`: Base ID for inventory workspace
+- `NUXT_PUBLIC_AIRTABLE_API_KEY`: Airtable personal access token (read/write)
+- `NUXT_PUBLIC_AIRTABLE_BASE_ID`: Base ID for inventory workspace
 
 ### Planned (Not Yet Implemented)
-- `VITE_BACKEND_PROXY_URL`: Backend proxy to hide Airtable credentials
-- `VITE_PROXY_AUTH_TOKEN`: Auth token for proxy
+- `NUXT_PUBLIC_BACKEND_PROXY_URL`: Backend proxy to hide Airtable credentials
+- `NUXT_PROXY_AUTH_TOKEN`: Auth token for proxy
 
 **Important**: Never commit `.env` files. Currently, Airtable credentials are exposed client-side; backend proxy is planned per `docs/specs/backend_proxy.md`.
 
@@ -656,7 +656,7 @@ After each testing session, ensure:
 2. **Airtable field names**: Use exact field names from Airtable schema (e.g., `'Expiry Date'` not `expiryDate`)
 3. **Image attachments**: Must use `[{ url: string }]` format, not plain URL strings
 4. **Stock quantity signs**: Don't manually negate quantities; use type parameter in `addStockMovement`
-5. **Environment variables**: All Vite env vars must be prefixed with `VITE_`
+5. **Environment variables**: Public values must be prefixed with `NUXT_PUBLIC_`, and secrets with `NUXT_`
 6. **Table name typos**: Always import and use `TABLES` constants from `lib/airtable.ts`
 7. **Path aliases**: Import shadcn components using `@/components/ui/` not relative paths like `../../components/ui/`
 8. **Design consistency**: Follow the "Fresh Precision" aesthetic - use CSS variables for colors, maintain rounded corners, and apply gradients to headers/footers

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ vercel                        # Deploy (see LAUNCH_CHECKLIST.md)
 ## Environment Variables
 
 Required for both local and production:
-- `VITE_AIRTABLE_API_KEY` - Your Airtable personal access token
-- `VITE_AIRTABLE_BASE_ID` - Your Airtable base ID
+- `NUXT_PUBLIC_AIRTABLE_API_KEY` - Your Airtable personal access token
+- `NUXT_PUBLIC_AIRTABLE_BASE_ID` - Your Airtable base ID
 
 **Never commit `.env` files.** They're gitignored by default.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -17,8 +17,8 @@ Complete guide for deploying the Grocery Inventory App to production.
 Set these in your hosting platform (Vercel, Netlify, etc.):
 
 ```bash
-VITE_AIRTABLE_API_KEY=your_personal_access_token_here
-VITE_AIRTABLE_BASE_ID=appXXXXXXXXXXXXXX
+NUXT_PUBLIC_AIRTABLE_API_KEY=your_personal_access_token_here
+NUXT_PUBLIC_AIRTABLE_BASE_ID=appXXXXXXXXXXXXXX
 ```
 
 ### Getting Your Airtable Credentials
@@ -60,8 +60,8 @@ VITE_AIRTABLE_BASE_ID=appXXXXXXXXXXXXXX
 
 4. **Add Environment Variables:**
    - Go to Project Settings → Environment Variables
-   - Add `VITE_AIRTABLE_API_KEY`
-   - Add `VITE_AIRTABLE_BASE_ID`
+   - Add `NUXT_PUBLIC_AIRTABLE_API_KEY`
+   - Add `NUXT_PUBLIC_AIRTABLE_BASE_ID`
    - Scope: Production, Preview, Development
 
 5. **Deploy:**

--- a/docs/PRODUCTION_BEST_PRACTICES.md
+++ b/docs/PRODUCTION_BEST_PRACTICES.md
@@ -1633,7 +1633,7 @@ Your inventory app is **architecturally excellent** but has **critical gaps** be
 **Current State**:
 ```typescript
 // lib/airtable.ts - EXPOSED IN BUNDLE
-const apiKey = import.meta.env.VITE_AIRTABLE_API_KEY; // ❌ Visible to all users
+const apiKey = import.meta.env.NUXT_PUBLIC_AIRTABLE_API_KEY; // ❌ Visible to all users
 ```
 
 **Production Standard**:

--- a/docs/REVIEW_ACTION_PLAN.md
+++ b/docs/REVIEW_ACTION_PLAN.md
@@ -64,12 +64,12 @@
 **Required Variables**:
 ```env
 # Airtable Configuration (TEMPORARY - will be moved to backend proxy)
-VITE_AIRTABLE_API_KEY=your_airtable_personal_token_here
-VITE_AIRTABLE_BASE_ID=appXXXXXXXXXXXXXX
+NUXT_PUBLIC_AIRTABLE_API_KEY=your_airtable_personal_token_here
+NUXT_PUBLIC_AIRTABLE_BASE_ID=appXXXXXXXXXXXXXX
 
 # Backend Proxy (when implemented - see docs/specs/backend_proxy.md)
-# VITE_BACKEND_PROXY_URL=http://localhost:3001
-# VITE_PROXY_AUTH_TOKEN=your_secure_token_here
+# NUXT_PUBLIC_BACKEND_PROXY_URL=http://localhost:3001
+# NUXT_PROXY_AUTH_TOKEN=your_secure_token_here
 ```
 
 **Acceptance Criteria**:
@@ -262,7 +262,7 @@ operations_safety.md (deployment)
 5. Notify team
 
 ### Emergency Disable
-1. Set VITE_BACKEND_PROXY_URL to maintenance endpoint
+1. Set NUXT_PUBLIC_BACKEND_PROXY_URL to maintenance endpoint
 2. Deploy immediately
 3. Investigate issue
 4. Restore service after fix
@@ -485,7 +485,7 @@ const BARCODE_PATTERNS = {
 ```
 
 ## Redaction Rules
-- Redact API keys: `VITE_AIRTABLE_API_KEY` → `***REDACTED***`
+- Redact API keys: `NUXT_PUBLIC_AIRTABLE_API_KEY` → `***REDACTED***`
 - Redact PII: email, phone numbers
 - Preserve correlation IDs and barcodes (non-sensitive)
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -411,8 +411,8 @@ export const useStockMutation = (product: Product) => {
 Before deploying to production, verify:
 
 ### Environment Variables
-- [ ] `VITE_AIRTABLE_API_KEY` is set in hosting platform
-- [ ] `VITE_AIRTABLE_BASE_ID` is set in hosting platform
+- [ ] `NUXT_PUBLIC_AIRTABLE_API_KEY` is set in hosting platform
+- [ ] `NUXT_PUBLIC_AIRTABLE_BASE_ID` is set in hosting platform
 
 ### CSP Headers (vercel.json)
 - [ ] `connect-src` includes `https://api.airtable.com`

--- a/docs/mvp_code_scaffolding.md
+++ b/docs/mvp_code_scaffolding.md
@@ -115,8 +115,8 @@ export default function ScanPage() {
 ```ts
 import Airtable from "airtable";
 
-const base = new Airtable({ apiKey: import.meta.env.VITE_AIRTABLE_KEY })
-  .base(import.meta.env.VITE_AIRTABLE_BASE);
+const base = new Airtable({ apiKey: import.meta.env.NUXT_PUBLIC_AIRTABLE_KEY })
+  .base(import.meta.env.NUXT_PUBLIC_AIRTABLE_BASE);
 
 export default base;
 ```

--- a/docs/specs/operations_safety.md
+++ b/docs/specs/operations_safety.md
@@ -73,7 +73,7 @@ Document operational safeguards to prevent accidental data exposure, clarify sec
 - Provide example `.env.example` with placeholders and no secrets.
 
 ## Deployment Checklist
-- Verify `.env` exists locally and in hosting secrets with `VITE_AIRTABLE_API_KEY`, `VITE_AIRTABLE_BASE_ID`, and proxy URL/token values populated.
+- Verify `.env` exists locally and in hosting secrets with `NUXT_PUBLIC_AIRTABLE_API_KEY`, `NUXT_PUBLIC_AIRTABLE_BASE_ID`, and proxy URL/token values populated.
 - Confirm Airtable base tables and field names match `src/lib/api.ts` expectations or updated backend proxy contract.
 - Ensure the backend proxy enforces authentication (shared secret token or per-user auth) and rate limiting before enabling client writes.
 - Run `pnpm lint`, `pnpm test` (once added), and `pnpm build` in CI; block release on failures.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -25,7 +25,7 @@ The Grocery Inventory App MVP is a tablet-friendly PWA designed to streamline st
 
 ## How to Test
 1. **Configure Environment**:
-   - Create `.env` with `VITE_AIRTABLE_API_KEY` and `VITE_AIRTABLE_BASE_ID`.
+   - Create `.env` with `NUXT_PUBLIC_AIRTABLE_API_KEY` and `NUXT_PUBLIC_AIRTABLE_BASE_ID`.
 2. **Run Locally**:
    ```bash
    npm run dev

--- a/init.sh
+++ b/init.sh
@@ -56,20 +56,20 @@ if [ ! -f ".env" ]; then
     if [ -f ".env.example" ]; then
         cp .env.example .env
         print_warning "Please edit .env and add your Airtable credentials:"
-        print_info "  - VITE_AIRTABLE_API_KEY"
-        print_info "  - VITE_AIRTABLE_BASE_ID"
+        print_info "  - NUXT_PUBLIC_AIRTABLE_API_KEY"
+        print_info "  - NUXT_PUBLIC_AIRTABLE_BASE_ID"
         echo ""
         read -p "Press Enter when you've updated .env..."
     else
         print_error ".env.example not found. Creating template..."
         cat > .env << 'ENVFILE'
 # Airtable Configuration
-VITE_AIRTABLE_API_KEY=your_api_key_here
-VITE_AIRTABLE_BASE_ID=your_base_id_here
+NUXT_PUBLIC_AIRTABLE_API_KEY=your_api_key_here
+NUXT_PUBLIC_AIRTABLE_BASE_ID=your_base_id_here
 
 # Optional: Backend Proxy (Post-MVP)
-# VITE_BACKEND_PROXY_URL=
-# VITE_PROXY_AUTH_TOKEN=
+# NUXT_PUBLIC_BACKEND_PROXY_URL=
+# NUXT_PROXY_AUTH_TOKEN=
 ENVFILE
         print_warning "Please edit .env and add your credentials, then run this script again."
         exit 1
@@ -81,7 +81,7 @@ fi
 # Check if credentials are set
 if grep -q "your_api_key_here" .env || grep -q "your_base_id_here" .env; then
     print_error "Airtable credentials not set in .env!"
-    print_info "Please update VITE_AIRTABLE_API_KEY and VITE_AIRTABLE_BASE_ID"
+    print_info "Please update NUXT_PUBLIC_AIRTABLE_API_KEY and NUXT_PUBLIC_AIRTABLE_BASE_ID"
     exit 1
 fi
 

--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -2,8 +2,8 @@ import Airtable from 'airtable';
 
 // Initialize Airtable client
 // Note: These env vars must be set in .env for the app to function
-const apiKey = import.meta.env.VITE_AIRTABLE_API_KEY;
-const baseId = import.meta.env.VITE_AIRTABLE_BASE_ID;
+const apiKey = import.meta.env.NUXT_PUBLIC_AIRTABLE_API_KEY;
+const baseId = import.meta.env.NUXT_PUBLIC_AIRTABLE_BASE_ID;
 
 if (!apiKey || !baseId) {
   console.warn('Missing Airtable credentials. Please check .env file.');

--- a/src/lib/imageUpload.ts
+++ b/src/lib/imageUpload.ts
@@ -9,7 +9,7 @@
 
 import { logger } from './logger';
 
-const IMGBB_API_KEY = import.meta.env.VITE_IMGBB_API_KEY;
+const IMGBB_API_KEY = import.meta.env.NUXT_PUBLIC_IMGBB_API_KEY;
 
 /**
  * Check if a string is a base64 data URL
@@ -50,7 +50,7 @@ async function uploadToVercelBlob(imageDataUrl: string): Promise<string> {
 async function uploadToImgbb(imageDataUrl: string): Promise<string> {
   if (!IMGBB_API_KEY) {
     throw new Error(
-      'Image upload not configured. In development, add VITE_IMGBB_API_KEY to .env. ' +
+      'Image upload not configured. In development, add NUXT_PUBLIC_IMGBB_API_KEY to .env. ' +
       'In production on Vercel, add BLOB_READ_WRITE_TOKEN.'
     );
   }
@@ -145,7 +145,7 @@ export async function uploadImage(imageUrl: string): Promise<string> {
       throw new Error(
         'Image upload failed. ' +
         'In production, ensure BLOB_READ_WRITE_TOKEN is set. ' +
-        'In development, ensure VITE_IMGBB_API_KEY is set.'
+        'In development, ensure NUXT_PUBLIC_IMGBB_API_KEY is set.'
       );
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vite.dev/config/
 export default defineConfig({
+  envPrefix: ['NUXT_PUBLIC_', 'NUXT_'],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- switch Airtable and image upload client environment variables to NUXT_PUBLIC_ prefixes and configure Vite to read them
- update application code and example env file to use the new names
- refresh documentation and setup scripts to document the renamed variables and proxy placeholders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c62b8bed08325ad0f2058c7ae459c)