### PR TITLE
Document Nuxt commands and migration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ cp .env.example .env
 # Edit .env and add your Airtable credentials
 ```
 
-**3. Run locally:**
+**3. Run locally (Nuxt):**
 ```bash
-pnpm dev
+pnpm nuxi dev
 ```
 
-**4. Deploy to production:**
+**4. Deploy to production (Nuxt + Vercel):**
 ```bash
-pnpm build                    # Test build
+pnpm nuxi build               # Generate production build
+pnpm nuxi preview             # Smoke-test the build locally (optional)
 vercel                        # Deploy (see LAUNCH_CHECKLIST.md)
 ```
 
@@ -53,11 +54,11 @@ Required for both local and production:
 
 ## Tech Stack
 
-- React 19 + TypeScript + Vite
+- Nuxt 3 (Vue 3) + TypeScript + Vite
 - TailwindCSS v4
 - Airtable (backend)
 - html5-qrcode (scanner)
-- React Query (data)
+- Vue Query (TanStack Query for Vue)
 - PWA ready
 
 ## Documentation

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Central index for the Grocery Inventory App documentation. Start here to find au
 - [Launch Checklist](../LAUNCH_CHECKLIST.md) — **ship to production this week** (step-by-step guide).
 - [Lean MVP Scope](specs/mvp_scope_lean.md) — **ACTIVE** - what ships this week.
 - [Environment Configuration](../.env.example) — required variables and safety reminders.
+- [React → Nuxt Migration Notes](migration/react-to-nuxt.md) — contributor changelog for the framework transition.
 
 ## Documentation Index
 | Document | Purpose | Status | Owner | Last Reviewed | Authority |

--- a/docs/migration/react-to-nuxt.md
+++ b/docs/migration/react-to-nuxt.md
@@ -1,0 +1,40 @@
+# React → Nuxt Migration Notes
+
+Guidance for contributors updating the Grocery Inventory App from its original React/Vite stack to Nuxt 3. Use this as a changelog for defaults, scripts, and architectural expectations while the codebase transitions.
+
+## Why Nuxt
+- Server-first rendering pipeline with file-based routing and server routes for Airtable proxy work.
+- Strong DX for TypeScript, Vue Query, and Vite-powered HMR.
+- Predictable deployment path to Vercel with zero-config serverless rendering.
+
+## Command Changes
+| Purpose | React (old) | Nuxt (new) |
+| --- | --- | --- |
+| Install deps | `pnpm install` | `pnpm install` |
+| Dev server | `pnpm dev` | `pnpm nuxi dev` |
+| Prod build | `pnpm build` | `pnpm nuxi build` |
+| Local preview | `pnpm preview` | `pnpm nuxi preview` |
+| Lint | `pnpm lint` | `pnpm lint` (package.json scripts retained) |
+
+## Framework & Library Swaps
+- **App framework:** React 19 → Nuxt 3 (Vue 3).
+- **Data fetching:** React Query → Vue Query (TanStack Query for Vue). Recreate hooks as composables in `composables/`.
+- **Routing:** React Router → Nuxt file-system routes in `pages/`.
+- **Stateful UI:** Replace React components with Vue SFCs using `<script setup>`; migrate contexts to Nuxt composables or plugins.
+- **PWA setup:** Keep existing manifest/icons; move Vite PWA config into Nuxt modules when available.
+
+## Deployment Notes
+- Build with `pnpm nuxi build`; test locally via `pnpm nuxi preview` before deploying to Vercel.
+- Vercel now detects Nuxt automatically; no custom build command needed beyond `pnpm nuxi build`.
+- Server routes for Airtable proxy should live in `server/api/` instead of `/api` React adapters.
+
+## Contributor Checklist
+- Update documentation references from React to Nuxt as you touch files.
+- Port shared utilities to `utils/` or `server/` as appropriate; avoid React-specific types.
+- Recreate React Query mutations as Vue Query `useMutation` composables with proper invalidation keys.
+- Validate camera and barcode scanning flows inside Nuxt layouts; adjust permissions prompts if layout-level guards differ.
+
+## Known Gaps To Fill
+- Nuxt module configuration for PWA and runtime config (`nuxt.config.ts`).
+- Vue component rewrites for scanner, inventory tables, and dialogs.
+- Automated tests need new runners (Vitest in Nuxt) once components are ported.


### PR DESCRIPTION
## Summary
- update README with Nuxt commands, deployment steps, and revised tech stack
- add React-to-Nuxt migration notes and link them from the docs index

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c62b9d92083258f1d69f6d8574059)