### PR TITLE
Add Nitro upload endpoint and blob config helper

### DIFF
--- a/server/api/upload.post.ts
+++ b/server/api/upload.post.ts
@@ -1,0 +1,47 @@
+import { createError, defineEventHandler, readBody } from 'h3';
+import { uploadBlobImage } from '../data-access/blob';
+
+interface UploadRequestBody {
+  image?: string;
+  filename?: string;
+}
+
+export default defineEventHandler(async (event) => {
+  if (event.node.req.method !== 'POST') {
+    throw createError({ statusCode: 405, statusMessage: 'Method not allowed' });
+  }
+
+  const { image, filename } = (await readBody<UploadRequestBody>(event)) || {};
+
+  if (!image) {
+    throw createError({ statusCode: 400, statusMessage: 'No image provided' });
+  }
+
+  if (!image.startsWith('data:image/')) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid image format. Expected base64 data URL.',
+    });
+  }
+
+  const matches = image.match(/^data:image\/(\w+);base64,(.+)$/);
+  if (!matches) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid base64 image format' });
+  }
+
+  const [, mimeType, base64Data] = matches;
+  const buffer = Buffer.from(base64Data, 'base64');
+
+  const timestamp = Date.now();
+  const randomId = Math.random().toString(36).substring(2, 8);
+  const finalFilename = filename || `product-${timestamp}-${randomId}.${mimeType === 'jpeg' ? 'jpg' : mimeType}`;
+
+  try {
+    const blob = await uploadBlobImage(event, finalFilename, buffer, `image/${mimeType}`);
+    return { url: blob.url };
+  } catch (error) {
+    console.error('Upload error:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    throw createError({ statusCode: 500, statusMessage: `Upload failed: ${message}` });
+  }
+});

--- a/server/data-access/blob.ts
+++ b/server/data-access/blob.ts
@@ -1,0 +1,26 @@
+import { put } from '@vercel/blob';
+import type { H3Event } from 'h3';
+import { useRuntimeConfig } from '#imports';
+
+/**
+ * Loads Blob configuration from Nuxt runtime config, falling back to environment variables.
+ */
+const getBlobToken = (event: H3Event): string | undefined => {
+  const runtimeConfig = useRuntimeConfig(event) as { blob?: { readWriteToken?: string } };
+  return runtimeConfig?.blob?.readWriteToken || process.env.BLOB_READ_WRITE_TOKEN;
+};
+
+export const uploadBlobImage = async (
+  event: H3Event,
+  filename: string,
+  buffer: Buffer,
+  contentType: string,
+) => {
+  const token = getBlobToken(event);
+
+  return put(filename, buffer, {
+    access: 'public',
+    contentType,
+    token,
+  });
+};


### PR DESCRIPTION
## Summary
- add a Nuxt/Nitro server upload route that mirrors the existing Vercel blob upload behavior
- centralize blob upload data-access to read tokens from Nuxt runtime config with env fallback for Vercel compatibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c62b81e308325bc058c3df33fc1a7)