### PR TITLE
Add language selection feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import OfflineIndicator from './components/OfflineIndicator';
+import { LanguageSelector } from './components/LanguageSelector';
 import { ToastProvider } from './hooks/useToast';
 import { Toaster } from 'sonner';
 import { BoxIcon, ShoppingCartIcon, ListIcon } from './components/ui/Icons';
@@ -60,10 +61,15 @@ function App() {
           <OfflineIndicator />
 
       <header className="mb-6 lg:mb-8 max-w-5xl mx-auto">
-        <Badge variant="outline" className="text-xs tracking-widest text-stone-400 uppercase font-bold bg-stone-50 border-stone-200 mb-2">
-          {t('app.subtitle')}
-        </Badge>
-        <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-stone-900">{t('app.title')}</h1>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <Badge variant="outline" className="text-xs tracking-widest text-stone-400 uppercase font-bold bg-stone-50 border-stone-200 mb-2">
+              {t('app.subtitle')}
+            </Badge>
+            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-stone-900">{t('app.title')}</h1>
+          </div>
+          <LanguageSelector />
+        </div>
       </header>
 
       <main className="w-full flex-1 flex flex-col items-center">

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'react-i18next';
+import { Globe } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { supportedLanguages, languageNames, type SupportedLanguage } from '@/i18n';
+
+export function LanguageSelector() {
+  const { i18n } = useTranslation();
+
+  const handleLanguageChange = (value: string) => {
+    i18n.changeLanguage(value);
+  };
+
+  return (
+    <Select value={i18n.language} onValueChange={handleLanguageChange}>
+      <SelectTrigger
+        className="w-auto min-w-[140px] h-9 border-2 border-stone-200 bg-white/80 backdrop-blur-sm hover:border-stone-300 focus:ring-[var(--color-lavender)] transition-colors"
+        aria-label="Select language"
+      >
+        <div className="flex items-center gap-2">
+          <Globe className="h-4 w-4 text-stone-500" />
+          <SelectValue>
+            {languageNames[i18n.language as SupportedLanguage] || i18n.language}
+          </SelectValue>
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        {supportedLanguages.map((lang) => (
+          <SelectItem
+            key={lang}
+            value={lang}
+            className="cursor-pointer"
+          >
+            {languageNames[lang]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export default LanguageSelector;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -5,8 +5,16 @@ import en from './locales/en.json';
 import ro from './locales/ro.json';
 import ru from './locales/ru.json';
 
-const supportedLanguages = ['es', 'en', 'ro', 'ru'] as const;
-type SupportedLanguage = (typeof supportedLanguages)[number];
+export const supportedLanguages = ['es', 'en', 'ro', 'ru'] as const;
+export type SupportedLanguage = (typeof supportedLanguages)[number];
+
+// Language display names in their native form (for selector UI)
+export const languageNames: Record<SupportedLanguage, string> = {
+  es: 'Español',
+  en: 'English',
+  ro: 'Română',
+  ru: 'Русский',
+};
 
 const getInitialLanguage = () => {
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
- Create LanguageSelector component using shadcn Select
- Export supported languages and native language names from i18n.ts
- Add language selector to app header with Globe icon
- Languages display in native form (Español, English, Română, Русский)
- Selection persists to localStorage via existing i18n event listener