### PR TITLE
fix: allow invoice OCR domain in CSP

### DIFF
--- a/todos/011-pending-p1-csp-allows-invoice-api.md
+++ b/todos/011-pending-p1-csp-allows-invoice-api.md
@@ -1,0 +1,117 @@
+---
+status: pending
+priority: p1
+issue_id: "011"
+tags: [code-review, security, ops, frontend]
+dependencies: []
+---
+
+# Allow invoice OCR API in CSP connect-src
+
+CSP blocks invoice OCR requests in production, breaking invoice import.
+
+## Problem Statement
+
+Invoice upload fails in production because the browser blocks the POST to the invoice OCR service. This blocks a user-critical feature (invoice import) and presents as a generic network error.
+
+## Findings
+
+- Browser console shows CSP violation: `connect-src` blocks `https://invoiceprocessing-gl4ol.onrender.com/extract`.
+- CSP is defined in `/Users/vladislavcaraseli/Documents/inventory-app/vercel.json` and does not include the invoice OCR service domain.
+- The invoice uploader calls `/extract` on `VITE_INVOICE_API_URL` (defaulting to `http://localhost:8000`), so production requires an allowlisted HTTPS domain.
+
+## Proposed Solutions
+
+### Option 1: Add specific OCR domain to CSP (recommended)
+
+**Approach:** Update `vercel.json` CSP `connect-src` to include `https://invoiceprocessing-gl4ol.onrender.com` (or the exact production API domain).
+
+**Pros:**
+- Minimal change
+- Keeps CSP tight
+- Fixes production immediately
+
+**Cons:**
+- Requires CSP update if domain changes
+
+**Effort:** 15-30 minutes
+
+**Risk:** Low
+
+---
+
+### Option 2: Use first-party proxy and only allow same-origin
+
+**Approach:** Route OCR requests through a Vercel API route (same origin), keep CSP `connect-src 'self'`.
+
+**Pros:**
+- Simplifies CSP
+- Keeps secrets server-side
+
+**Cons:**
+- More code and maintenance
+- Adds latency and infra costs
+
+**Effort:** 2-4 hours
+
+**Risk:** Medium
+
+---
+
+### Option 3: Allow `*.onrender.com` in CSP
+
+**Approach:** Add `https://*.onrender.com` to `connect-src`.
+
+**Pros:**
+- Flexible if domain changes
+
+**Cons:**
+- Overbroad; weakens CSP
+
+**Effort:** 10 minutes
+
+**Risk:** Medium
+
+## Recommended Action
+
+**To be filled during triage.**
+
+## Technical Details
+
+**Affected files:**
+- `/Users/vladislavcaraseli/Documents/inventory-app/vercel.json` - CSP `connect-src`
+- `/Users/vladislavcaraseli/Documents/inventory-app/src/lib/invoiceOCR.ts` - uses `VITE_INVOICE_API_URL`
+
+**Related components:**
+- Invoice upload dialog
+
+**Database changes:** No
+
+## Resources
+
+- Console error: CSP blocked `https://invoiceprocessing-gl4ol.onrender.com/extract`
+- Screenshot provided by user
+
+## Acceptance Criteria
+
+- [ ] Invoice upload succeeds on production domain
+- [ ] No CSP violations for OCR endpoint in console
+- [ ] CSP remains least-privilege (no wildcard if not required)
+
+## Work Log
+
+### 2026-02-06 - Initial Discovery
+
+**By:** Codex
+
+**Actions:**
+- Located CSP policy in `vercel.json`
+- Confirmed missing OCR domain in `connect-src`
+- Documented options and risks
+
+**Learnings:**
+- CSP needs explicit OCR domain allowlist to permit cross-origin upload
+
+## Notes
+
+- If `VITE_INVOICE_API_URL` changes, CSP must be updated accordingly.

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://*.vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://api.airtable.com https://*.airtable.com https://*.supabase.co https://world.openfoodfacts.org https://images.openfoodfacts.org https://vercel.live https://*.vercel.live; frame-ancestors 'none'; media-src 'self' blob:;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://*.vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://api.airtable.com https://*.airtable.com https://*.supabase.co https://world.openfoodfacts.org https://images.openfoodfacts.org https://invoiceprocessing-gl4ol.onrender.com https://vercel.live https://*.vercel.live; frame-ancestors 'none'; media-src 'self' blob:;"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Summary
- allow OCR API domain in CSP connect-src to fix invoice upload
- document finding in todo

## Testing
- pnpm test:e2e
- node scripts/validate-docs.js
