### PR TITLE
fix: correct OCR domain in CSP

### DIFF
--- a/todos/011-pending-p1-csp-allows-invoice-api.md
+++ b/todos/011-pending-p1-csp-allows-invoice-api.md
@@ -16,7 +16,7 @@ Invoice upload fails in production because the browser blocks the POST to the in
 
 ## Findings
 
-- Browser console shows CSP violation: `connect-src` blocks `https://invoiceprocessing-gl4ol.onrender.com/extract`.
+- Browser console shows CSP violation: `connect-src` blocks `https://invoiceprocessing-g4ol.onrender.com/extract`.
 - CSP is defined in `/Users/vladislavcaraseli/Documents/inventory-app/vercel.json` and does not include the invoice OCR service domain.
 - The invoice uploader calls `/extract` on `VITE_INVOICE_API_URL` (defaulting to `http://localhost:8000`), so production requires an allowlisted HTTPS domain.
 
@@ -24,7 +24,7 @@ Invoice upload fails in production because the browser blocks the POST to the in
 
 ### Option 1: Add specific OCR domain to CSP (recommended)
 
-**Approach:** Update `vercel.json` CSP `connect-src` to include `https://invoiceprocessing-gl4ol.onrender.com` (or the exact production API domain).
+**Approach:** Update `vercel.json` CSP `connect-src` to include `https://invoiceprocessing-g4ol.onrender.com` (or the exact production API domain).
 
 **Pros:**
 - Minimal change
@@ -89,7 +89,7 @@ Invoice upload fails in production because the browser blocks the POST to the in
 
 ## Resources
 
-- Console error: CSP blocked `https://invoiceprocessing-gl4ol.onrender.com/extract`
+- Console error: CSP blocked `https://invoiceprocessing-g4ol.onrender.com/extract`
 - Screenshot provided by user
 
 ## Acceptance Criteria

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://*.vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://api.airtable.com https://*.airtable.com https://*.supabase.co https://world.openfoodfacts.org https://images.openfoodfacts.org https://invoiceprocessing-gl4ol.onrender.com https://vercel.live https://*.vercel.live; frame-ancestors 'none'; media-src 'self' blob:;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://*.vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://api.airtable.com https://*.airtable.com https://*.supabase.co https://world.openfoodfacts.org https://images.openfoodfacts.org https://invoiceprocessing-g4ol.onrender.com https://vercel.live https://*.vercel.live; frame-ancestors 'none'; media-src 'self' blob:;"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Summary
- fix CSP allowlist to use correct Render OCR domain
- update todo notes to match actual domain

## Testing
- pnpm test:e2e
- node scripts/validate-docs.js
