### PR TITLE
fix(security): move invoice OCR auth to server-side proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,29 +85,33 @@ VITE_IMGBB_API_KEY=your_imgbb_api_key_here
 # 2. Returns structured product data with names, quantities, and prices
 # 3. Review and edit products before importing
 #
-# Architecture: FastAPI /extract endpoint
-# - Accepts PDF uploads via multipart/form-data
+# Architecture: Client -> /api/extract-invoice (Vercel function) -> FastAPI /extract
+# - API key stays server-side (never exposed in browser bundle)
+# - FastAPI still receives multipart/form-data uploads
 # - Returns JSON with products, supplier, invoice number, and total amount
-# - Supports API key authentication (optional for local dev)
 #
 # Setup Guide: docs/FASTAPI_INTEGRATION.md (create this)
 #
 # --- FastAPI Service Configuration ---
-# Local Development (default):
+# Local development fallback (direct call from browser only in DEV, no API key):
 VITE_INVOICE_API_URL=http://localhost:8000
-VITE_INVOICE_API_KEY=dev-key-12345
-VITE_INVOICE_API_REQUIRE_AUTH=false
 #
-# Production (Render.com) - uncomment for production use:
-# VITE_INVOICE_API_URL=https://invoiceprocessing-g4ol.onrender.com
-# VITE_INVOICE_API_KEY=<production-api-key-from-fastapi-service>
-# VITE_INVOICE_API_REQUIRE_AUTH=true
+# Proxy endpoint used by browser (optional, defaults to /api/extract-invoice):
+# VITE_INVOICE_PROXY_URL=/api/extract-invoice
+#
+# Server-side variables (set in Vercel/hosting dashboard, NOT in client bundle):
+INVOICE_API_URL=http://localhost:8000
+INVOICE_API_KEY=dev-key-12345
+INVOICE_PROXY_REQUIRE_AUTH=true
+#
+# Production (Render.com) - server-side values:
+# INVOICE_API_URL=https://invoiceprocessing-g4ol.onrender.com
+# INVOICE_API_KEY=<production-api-key-from-fastapi-service>
 #
 # Notes:
-# - API key is sent via X-API-Key header
-# - Set VITE_INVOICE_API_REQUIRE_AUTH=true to enforce authentication
-# - For local development, you can set VITE_INVOICE_API_REQUIRE_AUTH=false
+# - Browser never reads INVOICE_API_KEY (server-only secret)
 # - Production API key provided by FastAPI service owner
+# - VITE_INVOICE_API_URL is only used for local dev fallback when proxy is unavailable
 # - Cold start behavior: First upload after idle period (15min+) may take 30-60s
 
 # =============================================================================

--- a/api/extract-invoice.ts
+++ b/api/extract-invoice.ts
@@ -1,0 +1,125 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@supabase/supabase-js';
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+function resolveExtractUrl(): string | null {
+  const configuredBaseUrl = process.env.INVOICE_API_URL || process.env.VITE_INVOICE_API_URL;
+  if (!configuredBaseUrl) {
+    return null;
+  }
+
+  if (configuredBaseUrl.endsWith('/extract')) {
+    return configuredBaseUrl;
+  }
+
+  return `${configuredBaseUrl.replace(/\/$/, '')}/extract`;
+}
+
+function readBearerToken(req: VercelRequest): string | null {
+  const authorization = req.headers.authorization;
+  if (!authorization || !authorization.startsWith('Bearer ')) {
+    return null;
+  }
+
+  return authorization.slice('Bearer '.length).trim() || null;
+}
+
+function isAuthRequired(): boolean {
+  return process.env.INVOICE_PROXY_REQUIRE_AUTH !== 'false';
+}
+
+function createSupabaseAuthClient() {
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const supabaseAnonKey =
+    process.env.SUPABASE_ANON_KEY ||
+    process.env.SUPABASE_PUBLISHABLE_KEY ||
+    process.env.VITE_SUPABASE_ANON_KEY ||
+    process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return null;
+  }
+
+  return createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  });
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const extractUrl = resolveExtractUrl();
+  const apiKey = process.env.INVOICE_API_KEY;
+
+  if (!extractUrl) {
+    return res.status(500).json({ error: 'Missing INVOICE_API_URL server configuration' });
+  }
+
+  if (isAuthRequired()) {
+    const token = readBearerToken(req);
+    if (!token) {
+      return res.status(401).json({ error: 'Missing Bearer token' });
+    }
+
+    const supabase = createSupabaseAuthClient();
+    if (!supabase) {
+      return res.status(500).json({ error: 'Missing Supabase auth configuration for invoice proxy' });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data.user) {
+      return res.status(401).json({ error: 'Invalid or expired session token' });
+    }
+  }
+
+  const contentType = req.headers['content-type'];
+  if (!contentType || !contentType.includes('multipart/form-data')) {
+    return res.status(400).json({ error: 'Expected multipart/form-data request' });
+  }
+
+  const contentLengthHeader = req.headers['content-length'];
+  const contentLength = typeof contentLengthHeader === 'string' ? Number(contentLengthHeader) : NaN;
+  if (Number.isFinite(contentLength) && contentLength > MAX_FILE_SIZE_BYTES) {
+    return res.status(413).json({ error: 'File size exceeds 10MB limit. Please upload a smaller file.' });
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': contentType,
+      Accept: 'application/json',
+    };
+
+    if (apiKey) {
+      headers['X-API-Key'] = apiKey;
+    }
+
+    const upstreamResponse = await fetch(
+      extractUrl,
+      {
+        method: 'POST',
+        headers,
+        body: req as unknown as BodyInit,
+        // Required by Node.js fetch for streaming request bodies.
+        duplex: 'half',
+      } as RequestInit & { duplex: 'half' }
+    );
+
+    const responseText = await upstreamResponse.text();
+    const upstreamContentType = upstreamResponse.headers.get('content-type') || 'application/json';
+
+    res.status(upstreamResponse.status);
+    res.setHeader('Content-Type', upstreamContentType);
+    return res.send(responseText);
+  } catch (error) {
+    console.error('Invoice proxy error:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return res.status(502).json({ error: `Invoice extraction proxy failed: ${errorMessage}` });
+  }
+}

--- a/docs/FASTAPI_INTEGRATION.md
+++ b/docs/FASTAPI_INTEGRATION.md
@@ -1,825 +1,92 @@
 # FastAPI Integration Guide
 
-Complete guide for integrating and testing the FastAPI invoice extraction service with the inventory app.
-
-**Estimated Time**: 10-15 minutes
-
----
-
-## Table of Contents
-
-1. [Overview](#overview)
-2. [FastAPI Contract](#fastapi-contract)
-3. [Environment Configuration](#environment-configuration)
-4. [Local Development Setup](#local-development-setup)
-5. [Production Setup](#production-setup)
-6. [Manual Testing](#manual-testing)
-7. [Common Errors & Troubleshooting](#common-errors--troubleshooting)
-8. [API Reference](#api-reference)
-
----
+Guide for invoice extraction using a secure server-side proxy.
 
 ## Overview
 
-The inventory app uses a FastAPI service to extract product data from PDF invoices. This service replaces the previous Supabase Edge Functions approach with a direct, simpler API integration.
+Production flow:
+1. Browser uploads PDF to `/api/extract-invoice`
+2. Vercel function validates Supabase session
+3. Vercel function forwards file to FastAPI `/extract` with server-side `INVOICE_API_KEY`
+4. FastAPI returns structured invoice JSON
 
-**Key Benefits:**
-- **Simpler architecture**: Single API call instead of two-step OCR + parse
-- **Better performance**: No need for intermediate base64 encoding/decoding
-- **Easy testing**: Direct file upload via multipart/form-data
-- **Cost-effective**: Uses local or hosted FastAPI instance
+Local dev fallback:
+- If proxy is unavailable, browser can call `VITE_INVOICE_API_URL/extract` in development only.
 
-**Workflow:**
-1. Upload PDF invoice → FastAPI /extract endpoint
-2. FastAPI extracts text and products from PDF
-3. Returns structured JSON with products, supplier, and totals
-4. Review and import products into inventory
+## API Contract
 
----
+### App-facing endpoint
 
-## FastAPI Contract
+`POST /api/extract-invoice`
 
-### Endpoint
+Request:
+- `Content-Type: multipart/form-data`
+- field `file` (PDF)
+- header `Authorization: Bearer <supabase-access-token>` (required by default)
 
-```
-POST {VITE_INVOICE_API_URL}/extract
-```
+Response:
+- Pass-through from FastAPI `/extract`
 
-### Request
+Common errors:
+- `401` missing/invalid session token
+- `400` invalid multipart request / invalid PDF
+- `413` file too large (>10MB)
+- `5xx` proxy or upstream failure
 
-**Method:** `POST`
-**Content-Type:** `multipart/form-data`
-**Fields:**
-- `file`: PDF invoice file (required)
+### FastAPI endpoint (upstream)
 
-**Headers (Optional):**
-- `X-API-Key`: API key for authentication (required when `VITE_INVOICE_API_REQUIRE_AUTH=true`)
+`POST {INVOICE_API_URL}/extract`
 
-### Response 200 (Success)
-
-```json
-{
-  "products": [
-    {
-      "name": "Milk 1L",
-      "quantity": 12,
-      "unit_price": 1.35,
-      "total_price": 16.2,
-      "raw_code": "0123456789012"
-    }
-  ],
-  "supplier": "Supplier Name",
-  "invoice_number": "INV-123",
-  "date": "2026-02-01",
-  "total_amount": 123.45,
-  "currency": "EUR",
-  "confidence_score": 0.92
-}
-```
-
-**Field Mapping to App:**
-| FastAPI Field | App Field |
-|---------------|------------|
-| `date` | `invoiceDate` |
-| `raw_code` | `barcode` |
-| `unit_price` | `unitPrice` |
-| `total_price` | `totalPrice` |
-| `invoice_number` | `invoiceNumber` |
-| `total_amount` | `totalAmount` |
-
-**Ignored Fields:** `currency`, `confidence_score` (for future use)
-
-### Error Responses
-
-| Status | Description |
-|---------|-------------|
-| 401 | Invalid or missing API key |
-| 400 | Invalid file (not a PDF) |
-| 422 | Validation error (malformed PDF) |
-| 500 | Internal server error |
-
----
+Request from proxy:
+- `Content-Type: multipart/form-data`
+- `X-API-Key: <INVOICE_API_KEY>` (server-side)
 
 ## Environment Configuration
 
-### Required Environment Variables
-
-Create or update your `.env` file with the following variables:
+### Browser (`.env`)
 
 ```bash
-# FastAPI Service URL
+# Optional dev fallback (used only in DEV when proxy URL not used)
 VITE_INVOICE_API_URL=http://localhost:8000
 
-# API Key (required if VITE_INVOICE_API_REQUIRE_AUTH=true)
-VITE_INVOICE_API_KEY=dev-key-12345
-
-# Require Authentication (true for production, false for local dev)
-VITE_INVOICE_API_REQUIRE_AUTH=false
+# Optional; defaults to /api/extract-invoice
+# VITE_INVOICE_PROXY_URL=/api/extract-invoice
 ```
 
-### Variable Details
-
-#### VITE_INVOICE_API_URL
-- **Required:** Yes
-- **Default:** `http://localhost:8000`
-- **Description:** URL of the FastAPI service
-- **Examples:**
-  - Local: `http://localhost:8000`
-  - Docker: `http://localhost:8000` (same, but running in container)
-  - Production: `https://api.yourdomain.com`
-
-#### VITE_INVOICE_API_KEY
-- **Required:** Conditional (if `VITE_INVOICE_API_REQUIRE_AUTH=true`)
-- **Default:** `dev-key-12345` (for local development)
-- **Description:** API key for authentication
-- **Security:** Sent via `X-API-Key` header (client-side)
-- **Note:** For production, generate a secure random key
-
-#### VITE_INVOICE_API_REQUIRE_AUTH
-- **Required:** No (defaults to `false`)
-- **Values:** `true` or `false`
-- **Description:** Whether to enforce API key authentication
-- **Local Development:** Set to `false` to skip authentication
-- **Production:** Set to `true` to require API key
-
----
-
-## Local Development Setup
-
-### Option 1: Running FastAPI with Docker
-
-**Prerequisites:** Docker and Docker Compose installed
-
-1. **Navigate to FastAPI project directory:**
-   ```bash
-   cd /path/to/fastapi-service
-   ```
-
-2. **Start the service:**
-   ```bash
-   docker-compose up
-   ```
-
-3. **Verify it's running:**
-   ```bash
-   curl http://localhost:8000/health
-   ```
-
-4. **Stop when done:**
-   ```bash
-   docker-compose down
-   ```
-
-### Option 2: Running FastAPI with uvicorn
-
-**Prerequisites:** Python 3.8+, pip, and FastAPI project dependencies
-
-1. **Navigate to FastAPI project directory:**
-   ```bash
-   cd /path/to/fastapi-service
-   ```
-
-2. **Install dependencies:**
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-3. **Start the service:**
-   ```bash
-   uvicorn main:app --reload --host 0.0.0.0 --port 8000
-   ```
-
-4. **Verify it's running:**
-   ```bash
-   curl http://localhost:8000/health
-   ```
-
-5. **Stop with:** `Ctrl+C`
-
----
-
-## Production Setup
-
-### Step 1: Deploy FastAPI Service
-
-Deploy your FastAPI service to a production server:
-
-**Options:**
-- **Vercel:** Deploy as a serverless function
-- **AWS Lambda:** Deploy as a Lambda function with API Gateway
-- **Google Cloud Run:** Deploy as a containerized service
-- **Heroku/Render/Railway:** Deploy as a web service
-- **Your own VPS:** Deploy with Docker and nginx
-
-### Step 2: Configure Environment Variables
-
-In your production hosting platform:
-
-1. Set `VITE_INVOICE_API_URL` to your production URL
-   - Example: `https://api.yourdomain.com`
-
-2. Set `VITE_INVOICE_API_KEY` to a secure random key
-   - Generate with: `openssl rand -hex 32`
-   - Example: `abc123def456ghi789jkl012mno345pqr678`
-
-3. Set `VITE_INVOICE_API_REQUIRE_AUTH` to `true`
-
-### Step 3: Confirm .env.example Placeholders
-
-Ensure `.env.example` contains placeholder values only. Do **not** put production secrets in this file.
+### Server (Vercel/hosting env)
 
 ```bash
-VITE_INVOICE_API_URL=https://api.yourdomain.com
-VITE_INVOICE_API_KEY=your-production-api-key-here
-VITE_INVOICE_API_REQUIRE_AUTH=true
+# Required
+INVOICE_API_URL=https://your-fastapi-service.example.com
+INVOICE_API_KEY=your-fastapi-key
+
+# Supabase auth validation inputs (required when auth enabled)
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=sb_publishable_xxx
+# or SUPABASE_PUBLISHABLE_KEY=sb_publishable_xxx
+
+# Optional (default: true)
+INVOICE_PROXY_REQUIRE_AUTH=true
 ```
 
----
+## Local Development
 
-## Render Deployment
+1. Run FastAPI locally (`http://localhost:8000`).
+2. Run app (`pnpm dev`).
+3. Prefer proxy route if available.
+4. If proxy not running locally, DEV fallback uses `VITE_INVOICE_API_URL`.
 
-### Production Setup
+## Production Checklist
 
-#### FastAPI Service (Separate Repository)
+- `INVOICE_API_KEY` is set only as server env var.
+- No `VITE_INVOICE_API_KEY` in any client env/config.
+- `/api/extract-invoice` returns `401` without Bearer token.
+- Invoice upload works for signed-in users.
 
-The FastAPI invoice OCR service is deployed to Render.com free tier as a separate web service.
+## Migration Notes
 
-**Service URL**: https://invoiceprocessing-g4ol.onrender.com
+Removed from client-side setup:
+- `VITE_INVOICE_API_KEY`
+- `VITE_INVOICE_API_REQUIRE_AUTH`
 
-**Health Check**: https://invoiceprocessing-g4ol.onrender.com/health
-
-**Environment Variables** (Set in Render dashboard, not in frontend):
-- `OPENAI_API_KEY`: OpenAI API key (for GPT-4o mini parsing)
-- `GOOGLE_CLOUD_API_KEY`: Google Cloud Vision API key (for OCR)
-- `API_KEYS`: Production API key for frontend authentication
-- `RATE_LIMIT_PER_MINUTE`: Request rate limit (default: 60)
-- `MAX_FILE_SIZE`: Maximum file size in bytes (default: 10485760 = 10MB)
-
-#### Frontend Configuration (This Repository)
-
-Update environment variables in Vercel dashboard:
-
-```bash
-VITE_INVOICE_API_URL=https://invoiceprocessing-g4ol.onrender.com
-VITE_INVOICE_API_KEY=<production-api-key-from-fastapi-service>
-VITE_INVOICE_API_REQUIRE_AUTH=true
-```
-
-### Cold Start Behavior
-
-**Render Free Tier Limitation**:
-- Service spins down after 15 minutes of inactivity
-- Cold start takes 30-60 seconds
-- First upload after idle period: 38-72s total (30-60s cold start + 8-12s processing)
-
-**User Experience**:
-- Progress indicator stalls at 40% (upload complete) during cold start
-- XMLHttpRequest timeout: 120s minimum (size-adaptive, includes 60s cold start buffer)
-- Timeout error message: "Service is warming up (first upload may take 30-60 seconds). Please wait and try again."
-
-**Best Practices**:
-- Wait and retry on first upload timeout (service is warming up)
-- Subsequent uploads are faster (8-12s, service warm)
-- Monitor Render logs for error patterns
-
----
-
-## Manual Testing
-
-### Quick CLI Commands
-
-#### Check Server Health
-```bash
-curl -i http://localhost:8000/health
-# Expected: HTTP/1.1 200 OK
-```
-
-#### Test FastAPI Endpoint (No Auth)
-```bash
-curl -X POST http://localhost:8000/extract \
-  -H "Content-Type: multipart/form-data" \
-  -F "file=@/path/to/invoice.pdf"
-# Expected: JSON response with products array
-```
-
-#### Test FastAPI Endpoint (With Auth)
-```bash
-curl -X POST http://localhost:8000/extract \
-  -H "X-API-Key: dev-key-12345" \
-  -H "Content-Type: multipart/form-data" \
-  -F "file=@/path/to/invoice.pdf"
-# Expected: JSON response with products array
-```
-
-#### Test Frontend Server
-```bash
-curl -i http://localhost:5173
-# Expected: HTML response from React app
-```
-
-#### Monitor Console in Browser
-```javascript
-// Paste in DevTools Console (F12)
-// Monitor for errors during testing
-window.addEventListener('error', (e) => {
-  console.error('Error:', e);
-});
-// Filter Console by: error, warn
-```
-
----
-
-### Prerequisites Checklist
-
-### Prerequisites Checklist ✅
-
-Before starting manual testing, verify:
-
-#### Environment Setup
-- [ ] **FastAPI service running** - `curl http://localhost:8000/health`
-- [ ] **Frontend app running** - `curl http://localhost:5173`
-- [ ] **Environment variables configured** in `.env`:
-  - [ ] `VITE_INVOICE_API_URL=http://localhost:8000`
-  - [ ] `VITE_INVOICE_API_KEY=dev-key-12345`
-  - [ ] `VITE_INVOICE_API_REQUIRE_AUTH=false`
-
-#### Browser Tools
-- [ ] **DevTools Console open** (F12 on Windows/Linux, Option+Cmd+J on Mac)
-- [ ] **Network tab visible** for request monitoring
-- [ ] **Errors filter enabled** in Console
-- [ ] **Disable browser cache** for testing
-
-#### Test Data Preparation
-- [ ] **Sample invoice PDF ready** - Choose a test invoice with known products
-- [ ] **Expected results documented** - Note product names, quantities, prices
-- [ ] **Supplier info noted** - Know supplier name, invoice number, date (if present)
-
-1. **FastAPI service running** (see [Local Development Setup](#local-development-setup))
-2. **App running:** `pnpm dev`
-3. **Environment configured:** See [Environment Configuration](#environment-configuration)
-
-### Test 1: Upload PDF via App UI
-
-1. **Open the app:** Navigate to http://localhost:5173
-2. **Go to Inventory page**
-3. **Click "Import from Invoice" button**
-
-**Checkpoint:** ✅ Import dialog appears
-**Expected UI State:**
-```
-┌───────────────────────────────────┐
-│  Import from Invoice            │
-├───────────────────────────────────┤
-│  [Upload PDF Invoice Here]   │  ← Dialog
-└───────────────────────────────────┘
-```
-
-4. **Upload a PDF invoice:**
-   - Click "Select Invoice File"
-   - Choose a valid PDF invoice file
-
-**Checkpoint:** ✅ File selection completes
-**Checkpoint:** ✅ Progress bar starts moving
-**Expected UI State:**
-```
-┌───────────────────────────────────┐
-│  Import from Invoice            │
-├───────────────────────────────────┤
-│  Processing...               │  ← Progress Bar
-│  📊 30%                      │
-└───────────────────────────────────┘
-```
-
-5. **Verify extraction:**
-   - Preview table should appear with extracted products
-   - Supplier name (if present)
-   - Invoice number (if present)
-   - Total amount should match invoice
-
-**Checkpoint:** ✅ Preview table appears
-**Checkpoint:** ✅ Product count matches invoice
-**Checkpoint:** ✅ No console errors
-
-**Expected UI State:**
-```
-┌─────────────────────────────────────────────────┐
-│  ✅ Extraction Complete                  │
-├──────────────────────────────────────────────┤
-│  Product Name  | Qty  | Price  | Barcode  │
-│  Milk 1L       | 12    | €1.35  | 0123...  │
-│  Bread Whole    | 5     | €2.50  | 9876...  │
-│  ...                              │
-└───────────────────────────────────────────────┘
-```
-
-6. **Review and edit:**
-   - Check product names are correct
-   - Verify quantities and prices
-   - Add missing barcodes if needed
-
-**Checkpoint:** ✅ Edit mode activates
-**Checkpoint:** ✅ Changes saved successfully
-
-7. **Import products:**
-   - Click "Import [N] Products"
-   - Verify products are added to inventory
-   - Check stock IN movements were created
-
-**Checkpoint:** ✅ Import button enabled
-**Checkpoint:** ✅ Import completes successfully
-**Checkpoint:** ✅ Products visible in inventory
-
-#### Expected Results
-
-| Test Aspect | Expected Result | How to Verify |
-|-------------|-----------------|----------------|
-| **Products Extracted** | ✅ Count matches invoice line items | Count products in preview table |
-| **Product Names** | ✅ Names match invoice text | Compare name by name |
-| **Quantities** | ✅ Accurate to invoice | Verify qty column |
-| **Prices** | ✅ Unit and total match | Check unit_price × qty = total_price |
-| **Supplier Info** | ✅ Extracted if present | Check summary card at top |
-| **Barcodes** | ✅ Extracted if on invoice | Look for codes in preview table |
-| **Import Success** | ✅ Products appear in inventory | Navigate to inventory list, verify new items |
-| **Stock Movements** | ✅ Stock IN created | Check product details for stock count |
-| **Console Errors** | ❌ Zero errors | Check DevTools Console (F12) |
-| **Network Status** | ✅ 200 OK response | Check Network tab in DevTools |
-
-### Test 2: Test with curl
-
-**Test authentication (with API key):**
-```bash
-curl -X POST \
-  http://localhost:8000/extract \
-  -H "X-API-Key: dev-key-12345" \
-  -F "file=@/path/to/invoice.pdf"
-```
-
-**Test without authentication:**
-```bash
-curl -X POST \
-  http://localhost:8000/extract \
-  -F "file=@/path/to/invoice.pdf"
-```
-
-**Expected Output:** JSON response with extracted data (see [FastAPI Contract](#fastapi-contract))
-
-### Quick Test Scenarios
-
-#### Quick Test 1: Simple Invoice OCR (Sanity Check)
-
-**Purpose:** Verify basic end-to-end flow works
-
-**Steps:**
-```bash
-1. Upload any simple PDF invoice
-2. Verify products extracted (expect > 0)
-3. Import products
-4. Check inventory list
-```
-
-**Expected:** ✅ Products appear in inventory within 30 seconds
-
----
-
-#### Quick Test 2: Barcode Detection
-
-**Purpose:** Verify OCR extracts barcodes correctly
-
-**Steps:**
-```bash
-1. Upload invoice with known barcodes
-2. Check preview table for barcode column
-3. Verify codes match expected values
-```
-
-**Expected:** ✅ Barcodes displayed in preview (or "No barcode" if absent)
-
----
-
-#### Quick Test 3: Error Handling
-
-**Purpose:** Verify error messages are user-friendly
-
-**Steps:**
-```bash
-1. Upload non-PDF file (try .jpg)
-2. Verify error message appears
-3. Try empty/corrupted PDF
-4. Verify "Invalid PDF file" error
-```
-
-**Expected:** ✅ Clear, actionable error messages
-
----
-
-### Test 2: Test with curl
-
-### Test 3: Error Scenarios
-
-**Test 401 Unauthorized:**
-```bash
-curl -X POST \
-  http://localhost:8000/extract \
-  -H "X-API-Key: invalid-key" \
-  -F "file=@/path/to/invoice.pdf"
-```
-**Expected:** 401 status, error message about invalid API key
-
-**Test 400 Invalid File:**
-```bash
-curl -X POST \
-  http://localhost:8000/extract \
-  -F "file=@/path/to/image.jpg"
-```
-**Expected:** 400 status, error message about invalid file type
-
-**Test Empty/Invalid PDF:**
-```bash
-# Create empty PDF or corrupted PDF
-touch empty.pdf
-curl -X POST \
-  http://localhost:8000/extract \
-  -F "file=@empty.pdf"
-```
-**Expected:** 422 status, error message about invalid PDF
-
----
-
-## Common Errors & Troubleshooting
-
-### Troubleshooting Quick Reference
-
-| Symptom | Likely Cause | Quick Fix | Reference |
-|----------|---------------|------------|------------|
-| "Network error while processing" | FastAPI server down | `curl http://localhost:8000/health` | Step 1 in guide |
-| "Invalid or missing API key" | Env var missing or wrong | Check `.env` file values | Prerequisites |
-| "Invalid file type" | Not a PDF | Verify file is `.pdf` format | Error 400 |
-| "No products found" | Poor quality/handwritten invoice | Try cleaner invoice | Issue 422 |
-| Progress stuck at 50% | Server timeout | Check FastAPI logs | Network tab |
-| Products not importing | Backend mismatch | Verify Supabase connection | API docs |
-
-### Error Resolution Flowchart
-
-```text
-┌─────────────────────────┐
-│  Error Occurred?     │
-└──────────┬────────────┘
-           │
-           ├─ Network Error?
-           │  └─→ Check FastAPI server status
-           │     └─→ Verify VITE_INVOICE_API_URL
-           │
-           ├─ Auth Error (401)?
-           │  └─→ Check API key in .env
-           │     └─→ Set VITE_INVOICE_API_REQUIRE_AUTH=false
-           │
-           ├─ Validation Error (400/422)?
-           │  └─→ Check file is valid PDF
-           │     └─→ Try different invoice
-           │
-           └─ Empty Products?
-               └─→ Verify invoice has line items
-```
-
-### Error: "Network error while processing invoice"
-
-**Cause:** FastAPI service not running or unreachable
-
-**Solution:**
-1. Verify FastAPI service is running:
-   ```bash
-   curl http://localhost:8000/health
-   ```
-2. Check `VITE_INVOICE_API_URL` in `.env`
-3. Check network/firewall settings
-
-### Error: "Invalid or missing API key"
-
-**Cause:** Authentication required but key is missing or incorrect
-
-**Solution:**
-1. Set `VITE_INVOICE_API_KEY` in `.env`
-2. Set `VITE_INVOICE_API_REQUIRE_AUTH=false` for local dev
-3. Verify API key matches FastAPI service configuration
-
-### Error: "Invalid file type. Please upload a PDF file."
-
-**Cause:** Uploaded file is not a PDF
-
-**Solution:**
-1. Verify file extension is `.pdf`
-2. Check file MIME type is `application/pdf`
-3. Use a different PDF file if current one is corrupted
-
-### Error: "No products found in invoice"
-
-**Cause:** FastAPI couldn't extract any products from the PDF
-
-**Solution:**
-1. Ensure PDF is a valid invoice with product line items
-2. Check PDF quality (not scanned as image without OCR)
-3. Try a different PDF invoice file
-4. Contact FastAPI service administrator if issue persists
-
-### Error: "Invoice total amount not found in response"
-
-**Cause:** FastAPI response missing `total_amount` field
-
-**Solution:**
-1. Verify FastAPI service is returning complete responses
-2. Check FastAPI service logs for errors
-3. Contact FastAPI service administrator
-
-### Error: "Invalid response from invoice service"
-
-**Cause:** FastAPI response is malformed or unexpected
-
-**Solution:**
-1. Test FastAPI service with curl to verify it returns valid JSON
-2. Check FastAPI service logs for errors
-3. Verify FastAPI service version compatibility
-
----
-
-## Render-Specific Troubleshooting
-
-### CORS Errors
-
-**Symptom**: Browser console shows "Access-Control-Allow-Origin" error
-
-**Cause**: FastAPI CORS middleware not configured for production frontend URL
-
-**Solution**:
-1. Contact FastAPI service owner
-2. Verify CORS `allow_origins` includes production URL (`https://lavio.vercel.app`)
-3. Test CORS with curl:
-   ```bash
-   curl -I -X OPTIONS https://invoiceprocessing-g4ol.onrender.com/extract \
-     -H "Origin: https://lavio.vercel.app"
-   ```
-4. Redeploy FastAPI service if needed
-
-### 401 Unauthorized Errors
-
-**Symptom**: All upload requests return 401 error
-
-**Cause**: API key mismatch or missing authentication
-
-**Solution**:
-1. Verify `VITE_INVOICE_API_KEY` in Vercel matches FastAPI `API_KEYS`
-2. Verify `VITE_INVOICE_API_REQUIRE_AUTH=true` in Vercel
-3. Test API key with curl:
-   ```bash
-   curl -X POST https://invoiceprocessing-g4ol.onrender.com/extract \
-     -H "X-API-Key: <your-key>" \
-     -H "Content-Type: multipart/form-data" \
-     -F "file=@/path/to/test-invoice.pdf"
-   ```
-4. Contact FastAPI service owner if key is incorrect
-
-### Timeout Errors
-
-**Symptom**: Upload times out after 60+ seconds
-
-**Cause**: Render cold start (service waking up after 15+ minutes idle)
-
-**Solution**:
-1. Wait 30-60 seconds and retry upload
-2. Verify error message mentions "Service is warming up"
-3. If timeout persists, contact FastAPI service owner (service may be down)
-4. Check Render service logs: https://dashboard.render.com → invoice-ocr-api → Logs
-
-### Network Errors
-
-**Symptom**: "Network error while processing invoice"
-
-**Cause**: Actual internet connectivity issue, not cold start
-
-**Solution**:
-1. Check internet connection
-2. Try uploading smaller file
-3. Retry upload after network stabilizes
-4. If issue persists, contact support
-
-### Empty Products or Invalid Data
-
-**Symptom**: Extraction succeeds but returns empty products array or invalid data
-
-**Cause**: OCR failed to extract line items from invoice
-
-**Solution**:
-1. Verify invoice PDF is legible (not scanned image)
-2. Try different invoice (simpler layout)
-3. Contact support if issue persists
-
-### Render Service Unavailable (502/503)
-
-**Symptom**: HTTP error 502 Bad Gateway or 503 Service Unavailable
-
-**Cause**: FastAPI service crashed, restarting, or overloaded
-
-**Solution**:
-1. Wait 1-2 minutes and retry (service may be restarting)
-2. Check Render status page: https://status.render.com
-3. Check Render service logs for errors
-4. Contact FastAPI service owner if issue persists
-
----
-
-## API Reference
-
-### Field Mappings
-
-The app maps FastAPI response fields to internal data structures:
-
-| FastAPI Field | Type | App Field | Required |
-|---------------|-------|------------|----------|
-| `products` | Array | `products` | Yes |
-| `products[].name` | string | `name` | Yes |
-| `products[].quantity` | number | `quantity` | Yes |
-| `products[].unit_price` | number | `unitPrice` | Yes |
-| `products[].total_price` | number | `totalPrice` | Yes |
-| `products[].raw_code` | string (optional) | `barcode` | No |
-| `supplier` | string (optional) | `supplier` | No |
-| `invoice_number` | string (optional) | `invoiceNumber` | No |
-| `date` | string (optional) | `invoiceDate` | No |
-| `total_amount` | number (optional) | `totalAmount` | Yes |
-| `currency` | string (optional) | (ignored) | No |
-| `confidence_score` | number (optional) | (ignored) | No |
-
-### File Validation Rules
-
-| Rule | Requirement | Error Message |
-|-------|-------------|----------------|
-| MIME Type | `application/pdf` | "Invalid file type. Please upload a PDF file." |
-| Extension | `.pdf` | "Invalid file extension. Please upload a PDF file." |
-| Size | ≤ 10 MB | "File size exceeds 10MB limit. Please upload a smaller file." |
-
-### HTTP Status Codes
-
-| Code | Meaning | App Error Message |
-|------|----------|-------------------|
-| 200 | Success | N/A (products extracted) |
-| 401 | Unauthorized | "Invalid or missing API key. Please check your API configuration." |
-| 400 | Bad Request | "Invalid PDF file. Please ensure file is a valid PDF document." |
-| 422 | Unprocessable Entity | "Invalid PDF file. Please ensure file is a valid PDF document." |
-| 500 | Server Error | "Error processing invoice: 500 Internal Server Error" |
-
----
-
-## Support
-
-For issues with:
-- **App integration:** Check this guide and app logs
-- **FastAPI service:** Contact FastAPI service administrator
-- **API contract:** Review [FastAPI Contract](#fastapi-contract) section
-- **Testing:** See [Manual Testing](#manual-testing) section
-
-## Success Criteria Checklist
-
-### Environment Setup
-- [ ] FastAPI server responding to health checks
-- [ ] Frontend app loads without errors
-- [ ] Environment variables loaded correctly
-- [ ] No TypeScript or build errors in console
-
-### Invoice Extraction
-- [ ] PDF upload completes (no errors)
-- [ ] Progress bar reaches 100%
-- [ ] Preview table appears
-- [ ] Product count matches expectation
-- [ ] Supplier info extracted (if present)
-- [ ] Invoice number extracted (if present)
-- [ ] Total amount matches invoice
-
-### Data Quality
-- [ ] Product names accurate (95%+ match rate)
-- [ ] Quantities correct (±0 tolerance)
-- [ ] Unit prices correct (±€0.01 tolerance)
-- [ ] Total prices calculated correctly (unit × qty)
-- [ ] Barcodes extracted where present
-
-### Import Process
-- [ ] Products imported to inventory successfully
-- [ ] Stock IN movements created
-- [ ] Stock counts update correctly
-- [ ] No duplicate products created
-
-### Error Handling
-- [ ] Invalid file types rejected gracefully
-- [ ] Large files (>10MB) rejected
-- [ ] Network errors show user-friendly messages
-- [ ] Auth errors provide clear guidance
-- [ ] Empty products handled correctly
-
-### Console & Network
-- [ ] Zero unhandled exceptions
-- [ ] Zero console errors
-- [ ] Zero console warnings (except dev-mode warnings)
-- [ ] HTTP responses all 2xx (except expected 401/400/422)
-- [ ] Response times < 5 seconds
-
-### Overall
-- [ ] All critical tests pass ✅
-- [ ] Documentation completed and reviewed
-- [ ] Ready to merge to main
+These are intentionally deprecated for security reasons.

--- a/docs/FASTAPI_SECURITY_GUIDE.md
+++ b/docs/FASTAPI_SECURITY_GUIDE.md
@@ -1,618 +1,66 @@
-# FastAPI Invoice OCR Security Guide
+# FastAPI Invoice Security Guide
 
-**Last Updated**: 2026-02-04
-**Applies To**: Phase 3 Invoice OCR Implementation (PR #91)
+## Current Security Model
 
----
+Production invoice extraction uses a server-side proxy:
 
-## Executive Summary
+`Client -> /api/extract-invoice -> FastAPI /extract`
 
-The FastAPI invoice OCR integration uses client-side API key authentication. This document provides security best practices, deployment guidance, and mitigation strategies for production deployments.
+Security properties:
+- API key is server-only (`INVOICE_API_KEY`), not shipped to browser.
+- Proxy validates Supabase session token before forwarding request.
+- Browser never sends `X-API-Key`.
 
-**🔴 Critical Risk**: API key is exposed in production JavaScript bundle
+## Critical Rules
 
-**⚠️ Acceptable For**: Pre-production environments with proper mitigations
+1. Do not use `VITE_INVOICE_API_KEY` in client env.
+2. Keep `INVOICE_API_KEY` only in hosting server env variables.
+3. Keep `INVOICE_PROXY_REQUIRE_AUTH=true` in production.
+4. Reject unauthenticated proxy requests (`401`).
 
-**❌ Not Acceptable For**: Production without Vercel Edge Function proxy or strong mitigations
+## Required Environment Variables
 
----
-
-## Security Risk Assessment
-
-### Primary Vulnerability: Client-Side API Key Exposure
-
-**Location**: `src/lib/invoiceOCR.ts:131-146`
-
-```typescript
-const apiKey = import.meta.env.VITE_INVOICE_API_KEY;  // ← Embedded in bundle!
-if (requireAuth || apiKey) {
-  headers['X-API-Key'] = apiKey || '';
-}
-```
-
-**Impact**:
-- **Attack Surface**: Anyone with production app access can extract API key
-- **Exploit Scenario**:
-  1. Attacker opens DevTools → Network tab
-  2. Uploads any invoice
-  3. Inspects `X-API-Key` header
-  4. Uses extracted key to call FastAPI `/extract` indefinitely
-  5. Can process other users' invoice data (if FastAPI doesn't validate)
-
-**Risk Score**: 8/10 (Critical)
-
----
-
-## Deployment Modes
-
-### Mode 1: Local Development (Acceptable ✅)
-
-**Environment**: `localhost:8000` (default)
-
-**Security Posture**: **Low Risk**
-
-**Why Acceptable**:
-- API key not exposed to internet (localhost only)
-- Development data, no production impact
-- Rapid iteration enabled
-
-**Requirements**:
-- None required beyond local FastAPI service
-
----
-
-### Mode 2: Pre-Production/Staging (Acceptable with Mitigations ⚠️)
-
-**Environment**: Production or staging URLs
-
-**Security Posture**: **Medium Risk** (mitigations required)
-
-**Required Mitigations**:
-1. ✅ IP Whitelist on FastAPI service
-   - Restrict `/extract` endpoint to production server IPs only
-   - Block requests from unknown IPs
-   - Implementation: Configure FastAPI `ALLOWED_IPS` env var
-
-2. ✅ Rate Limiting on FastAPI
-   - Enforce 100 requests/day per API key
-   - Implement exponential backoff for rate limit violations
-   - Implementation: Configure FastAPI `RATE_LIMIT_PER_DAY=100`
-
-3. ✅ API Key Rotation
-   - Rotate keys weekly/monthly
-   - Implement key expiration (TTL 7 days)
-   - Revocation procedure for lost keys
-   - Implementation: Deploy cron job to regenerate keys
-
-4. ✅ Monitoring and Alerts
-   - Log all API requests with correlation IDs
-   - Alert on unusual patterns (sudden traffic spikes)
-   - Set up Prometheus/Grafana or cloud provider monitoring
-   - Implement: Add request logging to FastAPI
-
-5. ✅ CORS Domain Validation
-   - Restrict CORS to production domains only
-   - Validate `Origin` header on FastAPI
-   - Block requests from unauthorized origins
-   - Implementation: Configure FastAPI `ALLOWED_ORIGINS`
-
-6. ✅ Request Validation on FastAPI
-   - Validate file type server-side (PDF magic bytes)
-   - Reject malformed requests
-   - Validate file size (10MB max)
-   - Sanitize extracted data (remove XSS payloads)
-   - Implementation: Add Pydantic models to FastAPI
-
-**Deployment Checklist for Pre-Production**:
-```bash
-# FastAPI Service Configuration
-ALLOWED_IPS=["app.production.com", "load-balancer.production.com"]
-RATE_LIMIT_PER_DAY=100
-ALLOWED_ORIGINS=["https://app.inventory-app.com"]
-REQUEST_VALIDATION=true
-LOG_LEVEL=INFO
-CORS_ENABLED=true
-
-# App Configuration
-VITE_INVOICE_API_URL=https://fastapi.production.com/extract
-VITE_INVOICE_API_KEY=prod-key-xxx-xxx  # Rotatable
-VITE_INVOICE_API_REQUIRE_AUTH=true
-```
-
----
-
-### Mode 3: Production with Vercel Edge Function Proxy (Recommended ✅)
-
-**Architecture**:
-```
-Client → Vercel Edge Function (/api/extract-invoice)
-  → Validates Supabase user session
-  → Forwards request to FastAPI (/extract)
-  → Stores API key server-side (Vercel env var)
-  → Returns result to client
-```
-
-**Security Posture**: **Low Risk**
-
-**Benefits**:
-- ✅ API key never exposed to client
-- ✅ User authentication enforced
-- ✅ Server-side rate limiting
-- ✅ Audit logging via Supabase + Vercel
-- ✅ Defense-in-depth (client + server validation)
-
-**Implementation**: See [ADR-0005](../adrs/ADR-0005-invoice-ocr-architecture-evolution.md) for full details
-
----
-
-## Environment Variables
-
-### Current Configuration
+Server-side:
 
 ```bash
-# FastAPI Integration
-VITE_INVOICE_API_URL=https://fastapi-service.com/extract
-VITE_INVOICE_API_KEY=your-api-key-here
-VITE_INVOICE_API_REQUIRE_AUTH=true  # If true, require auth header
+INVOICE_API_URL=https://your-fastapi-service.example.com
+INVOICE_API_KEY=your-fastapi-key
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=sb_publishable_xxx
+INVOICE_PROXY_REQUIRE_AUTH=true
 ```
 
-### Security Considerations
+Client-side:
 
-**DO NOT**:
 ```bash
-# ❌ NEVER DO THIS
-VITE_INVOICE_API_KEY=secret-key-prod-xxx  # Production key in client bundle
-
-# ❌ NEVER DO THIS
-VITE_INVOICE_API_KEY=${FASTAPI_SERVICE_ADMIN_KEY} # Service admin key in app
+VITE_INVOICE_API_URL=http://localhost:8000   # optional dev fallback only
+# VITE_INVOICE_PROXY_URL=/api/extract-invoice
 ```
 
-**ALWAYS DO**:
-```bash
-# ✅ Production deployments must use Vercel Edge Function proxy
-# ✅ Pre-production must have all mitigations (Mode 2)
-# ✅ Local development only: VITE_INVOICE_API_URL=http://localhost:8000
-# ✅ Use unique, rotated keys per environment
-```
+## Validation Checklist
 
----
+- `rg "VITE_INVOICE_API_KEY|VITE_INVOICE_API_REQUIRE_AUTH" src .env*` returns no active usage.
+- Upload without Bearer token to `/api/extract-invoice` returns `401`.
+- Signed-in upload succeeds and forwards to FastAPI.
+- API key is not present in browser network requests.
 
-## Mitigation Implementation
+## Threats Mitigated
 
-### IP Whitelist on FastAPI
+- Client bundle key extraction.
+- Unlimited abuse via copied browser API key.
+- Direct anonymous access to extraction proxy (when auth required).
 
-**Purpose**: Restrict API access to production infrastructure only
+## Remaining Recommendations
 
-**Implementation**:
-```python
-# FastAPI service (Python)
-from fastapi import FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
-import os
+1. Add rate limiting in proxy and/or FastAPI.
+2. Log request metadata (without sensitive payloads).
+3. Enforce strict file validation server-side (MIME + size + extension).
+4. Consider per-user quotas for invoice extraction.
 
-ALLOWED_IPS = os.getenv("ALLOWED_IPS", "").split(",")
+## Deprecated Configuration
 
-app = FastAPI()
+Do not reintroduce:
+- `VITE_INVOICE_API_KEY`
+- `VITE_INVOICE_API_REQUIRE_AUTH`
 
-# IP whitelist middleware
-@app.middleware("http")
-async def ip_whitelist_middleware(request: Request, call_next):
-    client_ip = request.client.host
-    
-    # Check if client IP is in whitelist
-    if client_ip not in ALLOWED_IPS:
-        return JSONResponse(
-            status_code=403,
-            content={"error": "Forbidden - IP not whitelisted"}
-        )
-    
-    await call_next(request)
-
-# Or use trusted proxy (Cloudflare, AWS ALB)
-```
-
-**Configuration**:
-```bash
-# .env
-ALLOWED_IPS=app.server.com,load-balancer.app.com
-```
-
----
-
-### Rate Limiting on FastAPI
-
-**Purpose**: Prevent API abuse by enforcing request limits
-
-**Implementation**:
-```python
-# FastAPI service
-from fastapi import FastAPI, Request, HTTPException
-from slowapi import Limiter, RateLimiter
-from datetime import timedelta
-
-# Redis or in-memory rate limiter
-limiter = Limiter(
-    key="invoice_extract",
-    rate_limit=100,  # 100 requests per day
-    expiry=timedelta(days=1)  # Reset daily
-)
-
-@app.post("/extract")
-@limiter.limit("invoice_extract")
-async def extract_invoice(request: Request, file: UploadFile):
-    # Check rate limit
-    try:
-        limiter.hit("invoice_extract")
-    except RateLimiterExceeded:
-        raise HTTPException(
-            status_code=429,
-            detail="Rate limit exceeded. Maximum 100 requests per day."
-        )
-    
-    # Process extraction
-    # ...
-```
-
-**Configuration**:
-```bash
-# .env
-RATE_LIMIT_PER_DAY=100
-RATE_LIMIT_WINDOW=86400  # 24 hours in seconds
-```
-
----
-
-### Request Correlation and Audit Logging
-
-**Purpose**: Track API requests for security monitoring and debugging
-
-**Implementation**:
-```python
-# FastAPI service
-import uuid
-from fastapi import Request
-import logging
-
-logger = logging.getLogger("invoice_api")
-
-@app.post("/extract")
-async def extract_invoice(request: Request, file: UploadFile):
-    # Generate correlation ID
-    correlation_id = str(uuid.uuid4())
-    
-    # Log request with correlation ID
-    logger.info(
-        f"Invoice extraction request",
-        extra={
-            "correlation_id": correlation_id,
-            "client_ip": request.client.host,
-            "user_agent": request.headers.get("user-agent"),
-            "file_name": file.filename,
-            "file_size": file.size,
-        }
-    )
-    
-    # Add correlation ID to response
-    result = process_invoice(file)
-    result["correlation_id"] = correlation_id
-    
-    return result
-```
-
-**Benefits**:
-- Trace requests across client → proxy → FastAPI
-- Detect abuse patterns (high-frequency requests)
-- Debug issues with correlation IDs
-- Monitor API health and performance
-
----
-
-## Monitoring and Alerting
-
-### Required Metrics
-
-1. **Request Volume**
-   - Requests per minute/hour/day
-   - Errors per minute/hour/day
-   - Average response time
-
-2. **Security Events**
-   - Rate limit violations
-   - IP whitelist failures
-   - Suspicious activity patterns
-   - CORS violations
-
-3. **Business Metrics**
-   - Successful extractions
-   - Products extracted per invoice
-   - Average products per invoice
-
-### Monitoring Stack Options
-
-**Option 1: Cloud Provider (Recommended)**
-```yaml
-# Vercel Analytics (built-in)
-# FastAPI built-in metrics
-# DataDog or New Relic (third-party)
-```
-
-**Option 2: Self-Hosted**
-```yaml
-# Prometheus + Grafana
-# Loki + Tempo
-# Elastic Stack (ELK + Kibana)
-```
-
-### Alert Configuration
-
-```yaml
-# Prometheus AlertManager
-groups:
-  - name: security
-    rules:
-      - alert if rate_limit_violations > 10 in 5m
-      - alert if ip_whitelist_failures > 5 in 10m
-      
-  - name: availability
-    rules:
-      - alert if error_rate > 5% in 5m
-      - alert if avg_response_time > 30s
-```
-
----
-
-## Incident Response Plan
-
-### Security Incident Types
-
-1. **API Key Exposure**
-   - **Detection**: Unusual traffic from unknown IPs
-   - **Response**: Rotate API key immediately, investigate source
-   - **Recovery**: Generate new key, update environment
-
-2. **Rate Limit Violations**
-   - **Detection**: Single IP exceeding limits
-   - **Response**: Block IP temporarily, investigate
-   - **Recovery**: Add to permanent blocklist if abuse confirmed
-
-3. **Data Corruption Attempts**
-   - **Detection**: Malicious file uploads, invalid data
-   - **Response**: Block requests, log details
-   - **Recovery**: No action (attack prevented)
-
-### Incident Response Checklist
-
-```markdown
-## Security Incident Response
-
-### Detection
-- [ ] Incident detected (source, time, affected users)
-- [ ] Impact assessed (severity, scope)
-- [ ] Root cause identified
-
-### Containment
-- [ ] Attack vector blocked (IP throttled, key rotated, etc.)
-- [ ] Prevent spread to other systems
-- [ ] Temporary mitigation deployed
-
-### Eradication
-- [ ] Root cause fixed (code patch, config update)
-- [ ] Verify fix (testing, monitoring)
-- [ ] Permanent solution deployed
-- [ ] Post-incident review (lessons learned)
-
-### Recovery
-- [ ] Affected systems restored
-- [ ] Data integrity verified
-- [ ] Monitoring confirms normal operation
-- [ ] Incident closed (document in ADR/lessons/)
-```
-
----
-
-## Deployment Checklist
-
-### Pre-Production Deployment (Required Before Production)
-
-**Security:**
-- [ ] FastAPI IP whitelist configured
-- [ ] Rate limiting enabled (100 req/day)
-- [ ] Request correlation logging enabled
-- [ ] Monitoring and alerting configured
-- [ ] CORS domain validation enabled
-- [ ] Request validation enabled (file type, size)
-- [ ] API key rotation schedule established
-
-**Application:**
-- [ ] VITE_INVOICE_API_URL set to production domain
-- [ ] VITE_INVOICE_API_KEY configured (unique, rotated)
-- [ ] VITE_INVOICE_API_REQUIRE_AUTH=true
-- [ ] All tests passing (unit + integration)
-- [ ] Load testing performed (simulate high traffic)
-
-**Infrastructure:**
-- [ ] FastAPI service deployed (Docker/Kubernetes)
-- [ ] Database deployed (if using one)
-- [ ] Load balancer configured
-- [ ] CDN configured (if needed)
-- [ ] SSL/TLS certificates valid
-- [ ] Firewall rules configured
-- [ ] Monitoring stack operational
-
-**Documentation:**
-- [ ] This security guide reviewed
-- [ ] ADR-0005 approved
-- [ ] Incident response plan created
-- [ ] Runbook documented
-- [ ] Support team trained
-
-### Production Deployment (Blocked Without Mitigations)
-
-**🚫 DO NOT DEPLOY TO PRODUCTION WITHOUT**:
-
-- [ ] Vercel Edge Function proxy implemented
-- [ ] OR all Mode 2 mitigations implemented
-- [ ] Security review completed
-- [ ] Incident response plan tested
-
-**Reason**: Client-side API key exposure is a critical security vulnerability. Production deployment requires server-side API key protection.
-
----
-
-## Best Practices
-
-### Development
-
-✅ **DO**:
-- Use `VITE_INVOICE_API_URL=http://localhost:8000` for local development
-- Use mock/stub FastAPI for unit tests
-- Never commit production keys to code
-
-❌ **DO NOT**:
-- Use production API keys in local `.env`
-- Commit `VITE_INVOICE_API_KEY` values to repository
-- Test with real production data in local development
-
----
-
-### Deployment
-
-✅ **DO**:
-- Use environment-specific API keys (dev, staging, prod)
-- Rotate keys before deployment
-- Use secrets management (Vercel env vars, AWS Secrets Manager)
-- Enable all mitigations before production
-- Monitor for security events post-deployment
-
-❌ **DO NOT**:
-- Use same API key across all environments
-- Commit secrets to code
-- Deploy without security review
-- Disable monitoring in production
-
----
-
-### Operations
-
-✅ **DO**:
-- Review security logs weekly
-- Respond to alerts within 1 hour (critical), 4 hours (high)
-- Perform quarterly security audits
-- Rotate API keys quarterly
-- Update threat models based on incidents
-
-❌ **DO NOT**:
-- Ignore security alerts
-- Rotate keys reactively (only after incidents)
-- Deploy changes without security review
-- Disable monitoring due to cost
-
----
-
-## References
-
-**Internal Documentation:**
-- [ADR-0005: Invoice OCR Architecture Evolution](./adrs/ADR-0005-invoice-ocr-architecture-evolution.md)
-- [FASTAPI_INTEGRATION.md](./FASTAPI_INTEGRATION.md)
-- [Security Posture](./SECURITY_POSTURE.md)
-
-**External Resources:**
-- [OWASP API Security Top 10](https://owasp.org/www-project-top-ten/)
-- [FastAPI Security Best Practices](https://fastapi.tiangolo.com/tutorial/security/)
-- [Vercel Edge Functions Security](https://vercel.com/docs/concepts/functions/edge-functions/security)
-
----
-
-## Appendices
-
-### Appendix A: Sample FastAPI Security Configuration
-
-```python
-# FastAPI main.py
-from fastapi import FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
-from slowapi import Limiter, RateLimiter
-from slowapi.security import HTTPException, HTTPAuthorizationCredentials
-import os
-
-app = FastAPI()
-
-# Security headers
-@app.middleware("http")
-async def add_security_headers(request: Request, call_next):
-    response = await call_next(request)
-    response.headers["X-Content-Type-Options"] = "*"
-    response.headers["X-Content-Type"] = "application/json"
-    response.headers["X-Frame-Options"] = "DENY"
-    response.headers["X-XSS-Protection"] = "1; mode=block"
-    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
-    return response
-
-# CORS (configure for production only)
-allowed_origins = os.getenv("ALLOWED_ORIGINS", "").split(",")
-app.add_middleware(
-    CORSMiddleware(
-        allow_origins=allowed_origins,
-        allow_credentials=True,
-        allow_methods=["POST"],
-        allow_headers=["X-API-Key", "Content-Type"],
-        max_age=600,
-    )
-)
-
-# Rate limiting
-limiter = Limiter(
-    key="invoice_extract",
-    rate_limit=100,
-    expiry=timedelta(days=1),
-)
-
-# API key authentication
-@app.post("/extract")
-@limiter.limit("invoice_extract")
-async def extract_invoice(
-    request: Request,
-    file: UploadFile,
-    api_key: str = HTTPAuthorizationCredentials(scheme="Bearer", credentials=os.getenv("API_KEY"))
-):
-    # Validate API key
-    if api_key.credentials != os.getenv("API_KEY"):
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid API key"
-        )
-    
-    # Process extraction
-    # ...
-```
-
----
-
-### Appendix B: Incident Response Runbook
-
-**Template**: [INCIDENT_RUNBOOK_TEMPLATE.md](./INCIDENT_RUNBOOK_TEMPLATE.md)
-
-**Incident Types**:
-- **SEC001**: API Key Compromise
-- **SEC002**: Rate Limit Violation
-- **SEC003**: Data Corruption Attempt
-- **SEC004**: Unauthorized Access Attempt
-- **SEC005**: Malicious File Upload
-
-**Escalation Matrix**:
-```
-Severity | Escalation | Response Time
-----------|-----------|--------------
-Low      | Team Lead    | 4 hours
-Medium   | Engineering  | 2 hours
-High      | CTO        | 1 hour
-Critical  | CTO + Security | 30 minutes
-```
-
----
-
-**Document History:**
-
-| Version | Date | Author | Changes |
-|---------|------|---------|---------|
-| 1.0 | 2026-02-04 | Claude Code | Initial creation |
+These variables were removed to prevent client-side secret exposure.

--- a/src/lib/invoiceOCR.ts
+++ b/src/lib/invoiceOCR.ts
@@ -1,4 +1,5 @@
 import { logger } from './logger';
+import { supabase } from './supabase';
 
 export interface InvoiceProduct {
   name: string;
@@ -210,23 +211,32 @@ export async function extractInvoiceData(
 
     safeProgress(30);
 
-    // Prepare request to FastAPI /extract endpoint
-    const apiUrl = import.meta.env.VITE_INVOICE_API_URL || 'http://localhost:8000';
-    const extractUrl = `${apiUrl}/extract`;
+    // Use server-side proxy in production to avoid exposing API keys in client bundle.
+    const proxyUrl = import.meta.env.VITE_INVOICE_PROXY_URL;
+    const directDevApiUrl = import.meta.env.DEV ? import.meta.env.VITE_INVOICE_API_URL : undefined;
+    const extractUrl = proxyUrl
+      ? proxyUrl
+      : directDevApiUrl
+        ? `${directDevApiUrl.replace(/\/$/, '')}/extract`
+        : '/api/extract-invoice';
 
-    // Prepare headers with optional API key
+    // Forward user session when available so proxy can validate auth server-side.
     const headers: Record<string, string> = {};
-    const apiKey = import.meta.env.VITE_INVOICE_API_KEY;
-    const requireAuth = import.meta.env.VITE_INVOICE_API_REQUIRE_AUTH === 'true';
-
-    if (requireAuth || apiKey) {
-      headers['X-API-Key'] = apiKey || '';
+    try {
+      const { data } = await supabase.auth.getSession();
+      const token = data.session?.access_token;
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+    } catch (error) {
+      logger.warn('Unable to read Supabase session for invoice proxy request', {
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
     }
 
     logger.debug('Sending request to FastAPI /extract endpoint', {
       url: extractUrl,
-      hasApiKey: !!apiKey,
-      requireAuth,
+      mode: extractUrl === '/api/extract-invoice' || extractUrl === proxyUrl ? 'proxy' : 'direct-dev',
       fileName: file.name,
     });
 
@@ -287,7 +297,7 @@ export async function extractInvoiceData(
       });
       return {
         success: false,
-        error: 'Invalid or missing API key. Please check your API configuration.',
+        error: 'Unauthorized request. Please check your server-side invoice API configuration.',
       };
     }
 


### PR DESCRIPTION
## Summary
- add `/api/extract-invoice` serverless proxy for invoice extraction
- move FastAPI API key usage to server-side env vars (`INVOICE_API_KEY`, `INVOICE_API_URL`)
- validate Supabase bearer token in proxy before forwarding
- update client OCR flow to proxy-first and forward auth token
- refresh FastAPI integration/security docs for proxy architecture

## Validation
- `pnpm lint`
- `pnpm build`
- pre-commit hooks passed at commit time (Playwright E2E + docs validation)
