### PR TITLE
[codex] invoice import pricing parity and reliability fixes

### DIFF
--- a/docs/brainstorms/2026-02-11-invoice-import-pricing-parity-brainstorm.md
+++ b/docs/brainstorms/2026-02-11-invoice-import-pricing-parity-brainstorm.md
@@ -1,0 +1,58 @@
+---
+date: 2026-02-11
+topic: invoice-import-pricing-parity
+---
+
+# Invoice Import Pricing Parity
+
+## What We're Building
+Bring invoice upload behavior to parity with the existing Excel pricing workflow so owners can stop doing manual Excel work while preserving trusted pricing outputs.
+
+When importing supplier invoices, the app should compute the same transport-adjusted cost and margin tiers used in the spreadsheet:
+- `transport = weight * 1.5`
+- `price_euro = (invoice_line_total / quantity) / 19.5`
+- `price50 = (price_euro + transport) * 1.5`
+- `price70 = (price_euro + transport) * 1.7`
+- `price100 = (price_euro + transport) * 2.0`
+
+For weight sourcing, invoice import should first reuse catalog knowledge (existing product match by barcode/name). If a product is new and has no known weight, owner provides weight in the preview before confirm.
+
+For existing products found during import, invoice flow should update price tiers and add stock movement (restocking behavior), not skip.
+
+## Why This Approach
+### Recommended: Excel parity with catalog-weight fallback
+Pros:
+- Matches owner’s current trusted business logic exactly
+- Removes most manual Excel effort while keeping pricing confidence
+- Fits real grocery restock flow (update prices and stock together)
+
+Cons:
+- Requires explicit handling for missing weight on new products
+- More complex than plain margin-only calculations
+
+### Alternative A: Margin-only from OCR unit price
+Pros:
+- Simple and fast
+Cons:
+- Breaks parity with existing spreadsheet
+- Ignores transport, causing pricing drift
+
+### Alternative B: Keep base price only
+Pros:
+- Minimal implementation
+Cons:
+- Pushes manual pricing work back to owner
+- Fails core automation goal
+
+## Key Decisions
+- Pricing formulas must match Excel exactly, including transport and margin tiers.
+- Exchange rate is fixed at `19.5` for invoice import parity.
+- Weight source is existing catalog first; missing weight on new items is collected in preview.
+- Existing matched products are updated (price tiers) and stocked-in via stock movement.
+
+## Open Questions
+- No open product decisions for the brainstorm scope.
+- Implementation-level details (UI validation rules, matching confidence, conflict resolution precedence) are deferred to planning.
+
+## Next Steps
+Proceed to `/workflows:plan` to define implementation details, acceptance tests, and rollout sequence.

--- a/docs/plans/2026-02-11-feat-invoice-import-pricing-parity-plan.md
+++ b/docs/plans/2026-02-11-feat-invoice-import-pricing-parity-plan.md
@@ -1,0 +1,147 @@
+---
+title: "feat: Invoice Import Pricing Parity with Excel + Manual Weight Editing"
+type: "feat"
+date: "2026-02-11"
+brainstorm: "docs/brainstorms/2026-02-11-invoice-import-pricing-parity-brainstorm.md"
+---
+
+# feat: Invoice Import Pricing Parity with Excel + Manual Weight Editing
+
+## Overview
+Align invoice import pricing with the existing Excel workflow while keeping implementation simple and reliable now.
+
+Chosen architecture now:
+- FastAPI handles extraction + pricing preview
+- Frontend performs final DB writes (create/update + stock movement) via existing app data layer
+
+This avoids dependency on backend persistence mode and keeps invoice import working immediately with existing Supabase/Airtable flows.
+
+## Found Brainstorm Context
+Found brainstorm from `2026-02-11`: `invoice-import-pricing-parity`. Using as context for planning.
+
+Key decisions carried forward:
+- fixed FX rate `19.5`
+- transport formula `weightKg * 1.5`
+- margin tiers 50/70/100 based on landed cost
+- existing products should be updated and stocked in
+- allow manual weight adjustment per imported row
+- temporary density assumption for liquids: `1L = 1kg` and `1000ml = 1kg`
+
+## MVP Scope Lock (Updated)
+Build now:
+- `POST /extract`: include `row_id` and optional `weight_kg_candidate`
+- `POST /invoice/preview-pricing`: validate and compute prices; row status `ok | needs_input`
+- Frontend import writes to app DB (Supabase/Airtable) using existing create/update/stock APIs
+- Core error handling only (`INVALID_PAYLOAD`, `MISSING_WEIGHT`, `INTERNAL_ERROR` on preview path)
+- Rounding fixed to 4 decimals (as returned by preview API)
+
+Deferred to v2:
+- backend `/invoice/import` transactional endpoint + idempotency persistence
+- parse confidence/size tokens/match hints
+- rich warnings and expanded error taxonomy
+
+## Local Research Summary
+### Internal References
+- Current import orchestration entrypoint: `src/pages/InventoryListPage.tsx:296`
+- Existing create + stock flow already stable for xlsx: `src/pages/InventoryListPage.tsx:382`
+- Invoice review/edit flow: `src/components/invoice/InvoiceUploadDialog.tsx:55`
+- Import data shape shared between xlsx and invoice: `src/lib/xlsx/index.ts:16`
+- Existing update capability in API layer: `src/lib/api-provider.ts:57`
+- Existing pricing tier persistence in Supabase adapter: `src/lib/supabase-api.ts:421`
+
+### Institutional Learnings
+- Prevent NaN propagation in invoice numeric edits: `docs/solutions/ui-bugs/invoice-ocr-nan-input-validation-in-number-fields.md:22`
+- Keep runtime validation strict on OCR payload mapping: `docs/solutions/runtime-errors/invoice-ocr-runtime-product-field-validation.md:34`
+
+## Architecture Split (Simple Now)
+### Backend responsibilities (FastAPI)
+- OCR extraction and structured product rows.
+- Return `row_id` and optional `weight_kg_candidate`.
+- Validate + compute canonical pricing via `preview-pricing`.
+
+### Frontend responsibilities (Web app)
+- Upload PDF and show editable rows.
+- Enforce/collect `weightKg` before import.
+- Call `preview-pricing` and block import when rows are `needs_input`.
+- Perform final DB writes using app data APIs:
+  - match existing by barcode first, then normalized name
+  - update/create product prices
+  - add stock movement `IN`
+
+## Proposed Solution
+### 1) Backend API Usage (No backend write endpoint)
+Use only:
+- `POST /extract`
+- `POST /invoice/preview-pricing`
+
+Do not require `/invoice/import` for this phase.
+
+### 2) Frontend Dialog and Validation
+- Keep manual weight column and missing-weight gate.
+- Preserve safe numeric handling and text edit behavior.
+- Run preview-pricing before confirm import.
+
+Target files:
+- `src/components/invoice/InvoiceUploadDialog.tsx`
+- `src/lib/invoiceOCR.ts`
+- `src/locales/en.json`
+- `src/locales/ro.json`
+- `src/locales/es.json`
+- `src/locales/ru.json`
+
+### 3) Frontend Import Writes
+- Invoice import path computes/receives final prices from preview response.
+- Then write to DB via existing frontend data layer:
+  - update existing product or create new
+  - add stock movement
+- Keep xlsx import behavior unchanged.
+
+Target files:
+- `src/pages/InventoryListPage.tsx`
+- `src/lib/xlsx/index.ts`
+- `src/lib/invoiceImportApi.ts`
+
+## Acceptance Criteria
+- [ ] Invoice import formulas match parity through preview API output.
+- [ ] `row_id` and `weight_kg_candidate` are consumed from extract response.
+- [ ] User can manually edit weight per row.
+- [ ] Import blocked if any row is `needs_input`.
+- [ ] On import confirm, products are persisted in app DB (not in-memory-only backend state).
+- [ ] Existing matched product rows update price tiers and add stock-in.
+- [ ] New rows create products and add stock-in.
+- [ ] xlsx flow remains unchanged.
+- [ ] No NaN values can be persisted from invoice edits.
+
+## Implementation Tasks (Execution Checklist)
+- [ ] `src/lib/invoiceOCR.ts`: support `row_id`, optional `weight_kg_candidate` (`null` accepted).
+- [ ] `src/components/invoice/InvoiceUploadDialog.tsx`: weight UI + preview-pricing gate + payload mapping.
+- [ ] `src/lib/invoiceImportApi.ts`: keep preview client and auth headers.
+- [ ] `src/pages/InventoryListPage.tsx`: ensure invoice import writes through existing DB APIs.
+- [ ] `src/lib/xlsx/index.ts`: keep invoice metadata fields needed for import orchestration.
+- [ ] Add/adjust tests for missing-weight gate and invoice import persistence flow.
+- [ ] Run `pnpm test:unit` and `pnpm lint`.
+- [ ] Run explicit review pass before final commit.
+
+## Risks and Mitigations
+- Risk: frontend/backend formula drift.
+  - Mitigation: frontend uses preview API as pricing source before write.
+- Risk: wrong product match on normalized names.
+  - Mitigation: barcode-first match and strict normalization logic.
+- Risk: manual weight overhead.
+  - Mitigation: auto-fill from `weight_kg_candidate` + parse fallback from name prefix.
+
+## Testing and Validation
+### Automated
+- `pnpm test:unit`
+- `pnpm lint`
+
+### Manual
+- Import invoice with parseable sizes (`200G`, `0.5L`) and verify rows auto-fill weight.
+- Import invoice with missing size and verify UI blocks until weight entered.
+- Delete all products, import invoice, verify inventory list shows persisted products.
+- Confirm existing products are updated and stock increases.
+
+## Out of Scope (This Plan)
+- Backend transactional `/invoice/import` endpoint and idempotency persistence.
+- Persistent product `weight` column.
+- Dynamic FX source and density tables.

--- a/docs/specs/invoice-import-api-contract.md
+++ b/docs/specs/invoice-import-api-contract.md
@@ -1,0 +1,129 @@
+# Invoice Import API Contract (MVP - Simple Mode)
+
+Date: 2026-02-11
+Status: MVP Scope
+Related Plan: `docs/plans/2026-02-11-feat-invoice-import-pricing-parity-plan.md`
+
+## Scope (Build Now)
+- `POST /extract`: add `row_id` and optional `weight_kg_candidate`.
+- `POST /invoice/preview-pricing`: validate + compute prices; row status `ok` or `needs_input`.
+- Frontend performs final DB writes using existing app API layer (Supabase/Airtable path).
+- Matching for writes is handled in frontend import flow: barcode first, else normalized name, else create.
+- Rounding from preview response fixed to 4 decimals.
+
+## Deferred (v2)
+- backend `POST /invoice/import` transactional write endpoint
+- backend idempotency record table and replay behavior
+- parse confidence / size token / preview match hints
+- rich error taxonomy + advanced warnings
+
+## Constants (Server-Side for Preview)
+- `FX_LEI_TO_EUR = 19.5`
+- `TRANSPORT_RATE_PER_KG = 1.5`
+- Liquid approximation: `1L = 1kg`, `1000ml = 1kg`
+
+## Endpoint 1: Extract (extended)
+`POST /extract`
+
+Request:
+- `multipart/form-data`
+- field `file` (PDF)
+
+Response `200` (MVP fields):
+```json
+{
+  "supplier": "JLC",
+  "invoice_number": "INV-2026-001",
+  "date": "2026-02-11",
+  "total_amount": 1234.56,
+  "products": [
+    {
+      "row_id": "r1",
+      "name": "200G UNT CIOCOLATA JLC",
+      "quantity": 10,
+      "unit_price": 20.0,
+      "total_price": 200.0,
+      "raw_code": "1234567890123",
+      "weight_kg_candidate": 0.2
+    }
+  ]
+}
+```
+
+Notes:
+- `weight_kg_candidate` is optional (`null`/missing allowed).
+
+## Endpoint 2: Preview Pricing
+`POST /invoice/preview-pricing`
+
+Request:
+```json
+{
+  "invoice_meta": {
+    "supplier": "JLC",
+    "invoice_number": "INV-2026-001",
+    "date": "2026-02-11"
+  },
+  "rows": [
+    {
+      "row_id": "r1",
+      "name": "200G UNT CIOCOLATA JLC",
+      "barcode": "1234567890123",
+      "quantity": 10,
+      "line_total_lei": 200.0,
+      "weight_kg": 0.2
+    }
+  ]
+}
+```
+
+Response `200`:
+```json
+{
+  "rows": [
+    {
+      "row_id": "r1",
+      "status": "ok",
+      "computed": {
+        "base_price_eur": 1.0256,
+        "transport_eur": 0.3000,
+        "price_50": 1.9884,
+        "price_70": 2.2535,
+        "price_100": 2.6512
+      }
+    },
+    {
+      "row_id": "r2",
+      "status": "needs_input",
+      "computed": null
+    }
+  ]
+}
+```
+
+Row status enum:
+- `ok`
+- `needs_input`
+
+## Error Model (MVP)
+Error response:
+```json
+{
+  "error": {
+    "code": "MISSING_WEIGHT",
+    "message": "Weight is required"
+  }
+}
+```
+
+Supported codes (preview path):
+- `INVALID_PAYLOAD`
+- `MISSING_WEIGHT`
+- `INTERNAL_ERROR`
+
+## Frontend Expectations
+- Keep weight editable per row.
+- Call `preview-pricing` before import confirm.
+- Block import when any row status is `needs_input`.
+- Use preview `computed` values as source for persisted pricing.
+- Persist rows through existing frontend DB APIs (create/update + stock movement).

--- a/src/components/invoice/InvoiceUploadDialog.tsx
+++ b/src/components/invoice/InvoiceUploadDialog.tsx
@@ -32,6 +32,8 @@ import { Badge } from '@/components/ui/badge';
 import { suggestProductDetails } from '@/lib/ai';
 import { getBnmEurRate } from '@/lib/exchangeRates';
 import type { Product } from '@/types';
+import { parseWeightKgFromProductName } from '@/lib/invoicePricing';
+import { previewInvoicePricing } from '@/lib/invoiceImportApi';
 
 interface InvoiceUploadDialogProps {
   open: boolean;
@@ -42,6 +44,13 @@ interface InvoiceUploadDialogProps {
 
 type InvoiceStep = 'upload' | 'preview' | 'importing' | 'complete';
 
+const NUMERIC_EDITABLE_FIELDS: ReadonlySet<string> = new Set([
+  'quantity',
+  'unitPrice',
+  'totalPrice',
+  'weightKg',
+]);
+
 type ImportAction = 'create' | 'update' | 'skip';
 type MatchType = 'barcode' | 'name';
 
@@ -51,11 +60,11 @@ interface InvoiceMatchResult {
 }
 
 interface InvoicePreviewProduct extends InvoiceProduct {
+  weightKg?: number;
   category?: string;
   imageUrl?: string;
 }
 
-const ACTIVE_MARKUP = 70;
 const CATEGORIES = [
   'General',
   'Produce',
@@ -217,6 +226,7 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
         setRawProducts(result.data.products);
         setEditableProducts(result.data.products.map((product) => ({
           ...product,
+          weightKg: product.weightKgCandidate ?? parseWeightKgFromProductName(product.name),
           category: inferCategoryFromName(product.name),
         })));
         setImportActions({});
@@ -522,7 +532,10 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
         prev.map((product, i) => {
           if (i !== index) return product;
 
-          if (field === 'quantity' || field === 'unitPrice' || field === 'totalPrice') {
+          if (NUMERIC_EDITABLE_FIELDS.has(field)) {
+            if (typeof value === 'string' && value.trim() === '') {
+              return product;
+            }
             const numericValue = typeof value === 'number' ? value : Number(value);
             if (!isValidNumber(numericValue)) {
               return product;
@@ -547,33 +560,87 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
 
   const handleConfirmImport = useCallback(async () => {
     if (!editableProducts.length || !invoiceData || !isFxReady) return;
+    const missingWeightCount = editableProducts.filter((product) => !isValidNumber(product.weightKg)).length;
+    if (missingWeightCount > 0) {
+      setImportErrors([
+        t('invoiceUpload.errors.missingWeight', {
+          count: missingWeightCount,
+          defaultValue: '{{count}} products are missing weight. Please set weight before importing.',
+        }),
+      ]);
+      return;
+    }
 
     setStep('importing');
     setImportProgress({ current: 0, total: editableProducts.length });
     setImportErrors([]);
 
     try {
+      const preview = await previewInvoicePricing({
+        invoice_meta: {
+          supplier: invoiceData?.supplier,
+          invoice_number: invoiceData?.invoiceNumber,
+          date: invoiceData?.invoiceDate,
+        },
+        rows: editableProducts.map((product, index) => ({
+          row_id: product.rowId || `row-${index + 1}`,
+          name: product.name,
+          barcode: product.barcode || null,
+          quantity: product.quantity,
+          line_total_lei: roundCurrency(product.totalPrice * fxRate),
+          weight_kg: product.weightKg ?? null,
+        })),
+      });
+
+      const blockedRows = preview.rows.filter((row) => row.status !== 'ok');
+      if (blockedRows.length > 0) {
+        setImportErrors([
+          t('invoiceUpload.errors.previewBlocked', {
+            count: blockedRows.length,
+            defaultValue: '{{count}} rows need more input before import.',
+          }),
+        ]);
+        setStep('preview');
+        return;
+      }
+
+      const computedByRowId = new Map(
+        preview.rows.map((row) => [row.row_id, row.computed ?? null])
+      );
+
+      // Convert invoice products to ImportedProduct format
       const importedProducts: ImportedProduct[] = editableProducts.map((product, index) => {
         const match = matchResults[index];
         const importAction = importActions[index] ?? (match ? 'update' : 'create');
-        const price70 = Number.isFinite(product.unitPrice)
-          ? roundCurrency(product.unitPrice * (1 + ACTIVE_MARKUP / 100))
-          : undefined;
+        const rowId = product.rowId || `row-${index + 1}`;
+        const computed = computedByRowId.get(rowId);
+
+        if (!computed) {
+          throw new Error(
+            t('invoiceUpload.errors.previewMissingComputed', {
+              defaultValue: 'Preview pricing returned incomplete data. Please try again.',
+            })
+          );
+        }
 
         return {
           Name: product.name,
-          Barcode: product.barcode || '',
+          Barcode: product.barcode || undefined, // Can be empty, user can add later
           Category: product.category || 'General',
-          Price: product.unitPrice,
-          price70,
-          price50: undefined,
-          price100: undefined,
+          Price: computed.base_price_eur,
+          price50: computed.price_50,
+          price70: computed.price_70,
+          price100: computed.price_100,
           currentStock: product.quantity,
           Supplier: invoiceData?.supplier || undefined,
           expiryDate: undefined,
           importAction,
           existingProductId: importAction === 'update' ? match?.product.id : undefined,
           imageUrl: product.imageUrl,
+          importSource: 'invoice',
+          invoiceRowId: rowId,
+          weightKg: product.weightKg,
+          invoiceLineTotal: product.totalPrice,
         };
       });
 
@@ -611,7 +678,7 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
       setImportErrors([errorMessage]);
       setStep('preview');
     }
-  }, [editableProducts, invoiceData, importActions, isFxReady, matchResults, onImport, t]);
+  }, [editableProducts, fxRate, invoiceData, importActions, isFxReady, matchResults, onImport, t]);
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
@@ -856,6 +923,17 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
                 </div>
               )}
 
+              {editableProducts.some((p) => !isValidNumber(p.weightKg)) && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                  <p className="text-sm font-medium text-red-800 mb-1">
+                    {t('invoiceUpload.preview.missingWeightTitle', 'Weight required for transport cost')}
+                  </p>
+                  <p className="text-xs text-red-700">
+                    {t('invoiceUpload.preview.missingWeightDescription', 'Set missing product weights (kg) before importing.')}
+                  </p>
+                </div>
+              )}
+
               {/* Product Preview Table - Using shadcn Table components */}
               <div className="border-2 border-stone-200 rounded-lg overflow-hidden">
                 <div className="overflow-x-auto" style={{ maxHeight: 'calc(100vh - 500px)', minHeight: '300px' }}>
@@ -883,7 +961,10 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
                         <TableHead className="px-4 py-3 text-left font-semibold text-stone-700 w-[10%]">
                           {t('invoiceUpload.table.match', 'Match')}
                         </TableHead>
-                        <TableHead className="px-4 py-3 text-center font-semibold text-stone-700 w-[6%]">
+                        <TableHead className="px-4 py-3 text-right font-semibold text-stone-700 w-[9%]">
+                          {t('invoiceUpload.table.weightKg', 'Weight (kg)')}
+                        </TableHead>
+                        <TableHead className="px-4 py-3 text-center font-semibold text-stone-700 w-[10%]">
                           {t('invoiceUpload.table.actions', 'Actions')}
                         </TableHead>
                       </TableRow>
@@ -955,7 +1036,7 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
                                 <Input
                                   type="number"
                                   value={product.quantity}
-                                  onChange={(e) => handleProductFieldChange(i, 'quantity', Number(e.target.value))}
+                                  onChange={(e) => handleProductFieldChange(i, 'quantity', e.target.value)}
                                   className="h-9 text-sm text-right w-full"
                                   min="1"
                                 />
@@ -968,7 +1049,7 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
                                 <Input
                                   type="number"
                                   value={product.unitPrice}
-                                  onChange={(e) => handleProductFieldChange(i, 'unitPrice', Number(e.target.value))}
+                                  onChange={(e) => handleProductFieldChange(i, 'unitPrice', e.target.value)}
                                   className="h-9 text-sm text-right w-full"
                                   step="0.01"
                                   min="0"
@@ -982,13 +1063,31 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
                                 <Input
                                   type="number"
                                   value={product.totalPrice}
-                                  onChange={(e) => handleProductFieldChange(i, 'totalPrice', Number(e.target.value))}
+                                  onChange={(e) => handleProductFieldChange(i, 'totalPrice', e.target.value)}
                                   className="h-9 text-sm text-right w-full"
                                   step="0.01"
                                   min="0"
                                 />
                               ) : (
                                 <span className="font-semibold">€{product.totalPrice.toFixed(2)}</span>
+                              )}
+                            </TableCell>
+                            <TableCell className="px-4 py-3 text-right">
+                              {isEditing ? (
+                                <Input
+                                  type="number"
+                                  value={product.weightKg ?? ''}
+                                  onChange={(e) => handleProductFieldChange(i, 'weightKg', e.target.value)}
+                                  className="h-9 text-sm text-right w-full"
+                                  step="0.001"
+                                  min="0"
+                                />
+                              ) : isValidNumber(product.weightKg) ? (
+                                <span className="font-medium">{product.weightKg.toFixed(3)}</span>
+                              ) : (
+                                <span className="text-xs text-red-600 font-medium">
+                                  {t('invoiceUpload.table.missingWeight', 'Missing')}
+                                </span>
                               )}
                             </TableCell>
                             <TableCell className="px-4 py-3">
@@ -1180,7 +1279,7 @@ export function InvoiceUploadDialog({ open, onOpenChange, onImport, products }: 
               <Button
                 onClick={handleConfirmImport}
                 className="bg-[var(--color-forest)] hover:bg-[var(--color-forest-dark)] text-white"
-                disabled={!editableProducts.length || !isFxReady}
+                disabled={!editableProducts.length || !isFxReady || editableProducts.some((product) => !isValidNumber(product.weightKg))}
               >
                 {t('invoiceUpload.actions.importCount', {
                   count: editableProducts.length,

--- a/src/lib/invoiceImportApi.ts
+++ b/src/lib/invoiceImportApi.ts
@@ -1,0 +1,90 @@
+import { supabase } from './supabase';
+
+export interface InvoiceImportRowInput {
+  row_id: string;
+  name: string;
+  barcode: string | null;
+  quantity: number;
+  line_total_lei: number;
+  weight_kg: number | null;
+}
+
+export interface InvoiceMetaInput {
+  supplier?: string;
+  invoice_number?: string;
+  date?: string;
+}
+
+export interface PreviewPricingRequest {
+  invoice_meta?: InvoiceMetaInput;
+  rows: InvoiceImportRowInput[];
+}
+
+export interface PreviewPricingRow {
+  row_id: string;
+  status: 'ok' | 'needs_input';
+  messages?: string[];
+  computed?: {
+    base_price_eur: number;
+    transport_eur: number;
+    price_50: number;
+    price_70: number;
+    price_100: number;
+  } | null;
+}
+
+export interface PreviewPricingResponse {
+  rows: PreviewPricingRow[];
+  summary?: {
+    ok_count: number;
+    needs_input_count: number;
+    error_count?: number;
+  };
+}
+
+function getInvoiceApiBaseUrl(): string {
+  const proxyBaseUrl = import.meta.env.VITE_INVOICE_PROXY_BASE_URL as string | undefined;
+  if (proxyBaseUrl) return proxyBaseUrl.replace(/\/$/, '');
+
+  const directApiUrl = import.meta.env.VITE_INVOICE_API_URL as string | undefined;
+  if (directApiUrl) return directApiUrl.replace(/\/$/, '');
+
+  return '/api';
+}
+
+async function getAuthHeaders(extra: Record<string, string> = {}): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...extra,
+  };
+
+  const apiKey = import.meta.env.VITE_INVOICE_API_KEY as string | undefined;
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey;
+  }
+
+  const { data } = await supabase.auth.getSession();
+  const token = data.session?.access_token;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+export async function previewInvoicePricing(
+  payload: PreviewPricingRequest
+): Promise<PreviewPricingResponse> {
+  const baseUrl = getInvoiceApiBaseUrl();
+  const response = await fetch(`${baseUrl}/invoice/preview-pricing`, {
+    method: 'POST',
+    headers: await getAuthHeaders(),
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Preview pricing failed: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json() as Promise<PreviewPricingResponse>;
+}

--- a/src/lib/invoiceOCR.ts
+++ b/src/lib/invoiceOCR.ts
@@ -2,11 +2,13 @@ import { logger } from './logger';
 import { supabase } from './supabase';
 
 export interface InvoiceProduct {
+  rowId?: string;
   name: string;
   quantity: number;
   unitPrice: number;
   totalPrice: number;
   barcode?: string;
+  weightKgCandidate?: number;
 }
 
 export interface InvoiceData {
@@ -37,11 +39,13 @@ export const VALID_INVOICE_EXTENSIONS = ['.pdf'] as const;
 // FastAPI response interface
 interface FastAPIExtractResponse {
   products: Array<{
+    row_id?: string;
     name: string;
     quantity: number;
     unit_price: number;
     total_price: number;
     raw_code?: string;
+    weight_kg_candidate?: number | null;
   }>;
   supplier?: string;
   invoice_number?: string;
@@ -54,6 +58,7 @@ interface FastAPIExtractResponse {
  */
 function isValidProduct(product: FastAPIExtractResponse['products'][0]): boolean {
   return (
+    (product.row_id === undefined || typeof product.row_id === 'string') &&
     typeof product.name === 'string' &&
     product.name.trim().length > 0 &&
     product.name.length <= 500 &&
@@ -71,6 +76,12 @@ function isValidProduct(product: FastAPIExtractResponse['products'][0]): boolean
     !isNaN(product.total_price) &&
     Number.isFinite(product.total_price) &&
     product.total_price >= 0 &&
+    (product.weight_kg_candidate === undefined ||
+      product.weight_kg_candidate === null ||
+      (typeof product.weight_kg_candidate === 'number' &&
+        !isNaN(product.weight_kg_candidate) &&
+        Number.isFinite(product.weight_kg_candidate) &&
+        product.weight_kg_candidate > 0)) &&
     (product.raw_code === undefined ||
       (typeof product.raw_code === 'string' && product.raw_code.length <= 50))
   );
@@ -222,6 +233,10 @@ export async function extractInvoiceData(
 
     // Forward user session when available so proxy can validate auth server-side.
     const headers: Record<string, string> = {};
+    const apiKey = import.meta.env.VITE_INVOICE_API_KEY;
+    if (apiKey) {
+      headers['X-API-Key'] = apiKey;
+    }
     try {
       const { data } = await supabase.auth.getSession();
       const token = data.session?.access_token;
@@ -427,11 +442,13 @@ export async function extractInvoiceData(
     // Map FastAPI response to InvoiceData (now validated)
     const invoiceData: InvoiceData = {
       products: responseData.products.map((product) => ({
+        rowId: product.row_id,
         name: product.name,
         quantity: product.quantity,
         unitPrice: product.unit_price,
         totalPrice: product.total_price,
         barcode: product.raw_code,
+        weightKgCandidate: product.weight_kg_candidate ?? undefined,
       })),
       supplier: responseData.supplier,
       invoiceNumber: responseData.invoice_number,

--- a/src/lib/invoicePricing.ts
+++ b/src/lib/invoicePricing.ts
@@ -1,0 +1,15 @@
+export function parseWeightKgFromProductName(name: string): number | undefined {
+  if (!name) return undefined;
+
+  const match = name.trim().match(/^(\d+(?:[.,]\d+)?)\s*(kg|g|ml|l)\b/i);
+  if (!match) return undefined;
+
+  const rawValue = Number.parseFloat(match[1].replace(',', '.'));
+  if (!Number.isFinite(rawValue) || rawValue <= 0) return undefined;
+
+  const unit = match[2].toLowerCase();
+  if (unit === 'kg' || unit === 'l') return rawValue;
+  if (unit === 'g' || unit === 'ml') return rawValue / 1000;
+
+  return undefined;
+}

--- a/src/lib/xlsx/index.ts
+++ b/src/lib/xlsx/index.ts
@@ -28,6 +28,10 @@ export interface ImportedProduct {
   importAction?: 'create' | 'update' | 'skip';
   existingProductId?: string;
   imageUrl?: string;
+  importSource?: 'xlsx' | 'invoice';
+  invoiceRowId?: string;
+  weightKg?: number;
+  invoiceLineTotal?: number;
 }
 
 export interface ImportResult {

--- a/src/pages/InventoryListPage.tsx
+++ b/src/pages/InventoryListPage.tsx
@@ -299,6 +299,160 @@ const InventoryListPage = ({ onBack }: InventoryListPageProps) => {
     let skipCount = 0;
     let errorCount = 0;
     const failedProducts: Array<{ name: string; error: string }> = [];
+    const partialProducts: Array<{ name: string; error: string }> = [];
+
+    const importSources = new Set(importedProducts.map((product) => product.importSource ?? 'xlsx'));
+    if (importSources.size > 1) {
+      logger.error('Mixed import sources in single batch', {
+        importSources: Array.from(importSources),
+        rowCount: importedProducts.length,
+      });
+      showToast(
+        'error',
+        t('import.failed'),
+        t('import.mixedSourcesNotSupported', 'Import batch contains mixed sources. Please import invoice and XLSX files separately.'),
+        8000
+      );
+      return;
+    }
+
+    const isInvoiceImport = importSources.has('invoice');
+    if (isInvoiceImport) {
+      const normalizedNameMap = new Map<string, Product>();
+      const normalizeName = (value: string): string => value.toLowerCase().replace(/\s+/g, ' ').trim();
+      products.forEach((product) => {
+        const normalized = normalizeName(product.fields.Name);
+        if (!normalizedNameMap.has(normalized)) {
+          normalizedNameMap.set(normalized, product);
+        }
+      });
+
+      for (const imported of importedProducts) {
+        try {
+          let existing: Product | null = null;
+          if (imported.Barcode) {
+            existing = await getProductByBarcode(imported.Barcode);
+          }
+          if (!existing) {
+            existing = normalizedNameMap.get(normalizeName(imported.Name)) ?? null;
+          }
+          if (existing) {
+            normalizedNameMap.set(normalizeName(imported.Name), existing);
+          }
+
+          if (existing) {
+            await updateProduct(existing.id, {
+              Price: imported.Price,
+              'Price 50%': imported.price50,
+              'Price 70%': imported.price70,
+              'Price 100%': imported.price100,
+              Supplier: imported.Supplier,
+            });
+
+            if (imported.currentStock && imported.currentStock > 0) {
+              try {
+                await addStockMovement(existing.id, imported.currentStock, 'IN');
+              } catch (stockErr) {
+                const stockErrorMessage = stockErr instanceof Error ? stockErr.message : t('errors.unknownError');
+                partialProducts.push({
+                  name: imported.Name,
+                  error: t('import.partialStockFailed', {
+                    defaultValue: 'Product updated, but stock movement failed: {{message}}',
+                    message: stockErrorMessage,
+                  }),
+                });
+                logger.error('Invoice import stock movement failed after product update', {
+                  productId: existing.id,
+                  productName: imported.Name,
+                  quantity: imported.currentStock,
+                  errorMessage: stockErrorMessage,
+                  errorStack: stockErr instanceof Error ? stockErr.stack : undefined,
+                  timestamp: new Date().toISOString(),
+                });
+                continue;
+              }
+            }
+          } else {
+            const newProduct = await createProduct({
+              Name: imported.Name,
+              Barcode: imported.Barcode,
+              Category: imported.Category,
+              Price: imported.Price,
+              'Price 50%': imported.price50,
+              'Price 70%': imported.price70,
+              'Price 100%': imported.price100,
+              Markup: 70,
+              'Expiry Date': imported.expiryDate,
+              Supplier: imported.Supplier,
+            });
+            normalizedNameMap.set(normalizeName(imported.Name), newProduct);
+
+            if (imported.currentStock && imported.currentStock > 0 && newProduct) {
+              try {
+                await addStockMovement(newProduct.id, imported.currentStock, 'IN');
+              } catch (stockErr) {
+                const stockErrorMessage = stockErr instanceof Error ? stockErr.message : t('errors.unknownError');
+                partialProducts.push({
+                  name: imported.Name,
+                  error: t('import.partialStockFailed', {
+                    defaultValue: 'Product created, but stock movement failed: {{message}}',
+                    message: stockErrorMessage,
+                  }),
+                });
+                logger.error('Invoice import stock movement failed after product creation', {
+                  productId: newProduct.id,
+                  productName: imported.Name,
+                  quantity: imported.currentStock,
+                  errorMessage: stockErrorMessage,
+                  errorStack: stockErr instanceof Error ? stockErr.stack : undefined,
+                  timestamp: new Date().toISOString(),
+                });
+                continue;
+              }
+            }
+          }
+
+          successCount += 1;
+        } catch (err) {
+          logger.error('Invoice import row failed', {
+            productName: imported.Name,
+            barcode: imported.Barcode,
+            errorType: err instanceof Error ? err.constructor.name : typeof err,
+            errorMessage: err instanceof Error ? err.message : String(err),
+            errorStack: err instanceof Error ? err.stack : undefined,
+            timestamp: new Date().toISOString(),
+          });
+          errorCount += 1;
+          failedProducts.push({
+            name: imported.Name,
+            error: err instanceof Error ? err.message : t('errors.unknownError'),
+          });
+        }
+      }
+
+      await refetch();
+
+      if (successCount > 0 || partialProducts.length > 0) {
+        let message = t('import.successMessage', { count: successCount, skipped: 0, errors: errorCount });
+        if (partialProducts.length > 0) {
+          const partialList = partialProducts.slice(0, 3).map(f => `• ${f.name}: ${f.error}`).join('\n');
+          const remainingPartial = partialProducts.length > 3 ? `\n... and ${partialProducts.length - 3} more` : '';
+          message += `\n\n${t('import.partialProducts', 'Partially imported products')}:\n${partialList}${remainingPartial}`;
+        }
+        if (failedProducts.length > 0) {
+          const failedList = failedProducts.slice(0, 3).map(f => `• ${f.name}: ${f.error}`).join('\n');
+          const remaining = failedProducts.length > 3 ? `\n... and ${failedProducts.length - 3} more` : '';
+          message += `\n\n${t('import.failedProducts', 'Failed products')}:\n${failedList}${remaining}`;
+        }
+        showToast(errorCount > 0 || partialProducts.length > 0 ? 'warning' : 'success', t('import.success'), message, 8000);
+      } else {
+        const message = failedProducts.length > 0
+          ? failedProducts.slice(0, 3).map(f => `• ${f.name}: ${f.error}`).join('\n')
+          : t('import.failedMessage', { count: errorCount });
+        showToast('error', t('import.failed'), message, 8000);
+      }
+      return;
+    }
 
     for (const imported of importedProducts) {
       try {
@@ -444,7 +598,7 @@ const InventoryListPage = ({ onBack }: InventoryListPageProps) => {
         8000
       );
     }
-  }, [refetch, showToast, t]);
+  }, [products, refetch, showToast, t]);
 
   return (
     <div className="fixed inset-0 bg-gradient-to-br from-stone-100 to-stone-200 overflow-hidden">

--- a/todos/011-complete-p1-invoice-import-duplicate-name-creation.md
+++ b/todos/011-complete-p1-invoice-import-duplicate-name-creation.md
@@ -1,0 +1,105 @@
+---
+status: complete
+priority: p1
+issue_id: "011"
+tags: [code-review, data-integrity, invoice-import]
+dependencies: []
+---
+
+# Invoice import creates duplicates for repeated names
+
+The invoice import path can create duplicate product records when the same product name appears multiple times in one invoice and barcode is missing.
+
+## Problem Statement
+
+Invoice rows are matched against a normalized-name map built from the pre-import product list only. Newly created products are not added back into that map during the same import run. As a result, repeated rows in one invoice can create duplicate products instead of updating/stocking a single product.
+
+## Findings
+
+- `src/pages/InventoryListPage.tsx:304` creates `normalizedNameMap` once from `products` state.
+- `src/pages/InventoryListPage.tsx:336` creates a new product when no match is found.
+- There is no `normalizedNameMap.set(...)` after creation, so later rows in the same batch cannot match the just-created product.
+- Impact: duplicate SKUs and fragmented stock history from a single import action.
+
+## Proposed Solutions
+
+### Option 1: Update in-memory map after create (recommended)
+
+After `createProduct`, insert the returned product into `normalizedNameMap` by normalized name and barcode cache.
+
+**Pros:**
+- Minimal change.
+- Fixes same-batch duplicates immediately.
+
+**Cons:**
+- Keeps current sequential import architecture.
+
+**Effort:** Small
+
+**Risk:** Low
+
+---
+
+### Option 2: Pre-group invoice rows by matching key
+
+Group rows by barcode/name before writes and execute one create/update per group, summing stock deltas.
+
+**Pros:**
+- Deterministic dedupe and fewer DB calls.
+
+**Cons:**
+- Larger refactor.
+- More edge-case handling.
+
+**Effort:** Medium
+
+**Risk:** Medium
+
+## Recommended Action
+
+
+## Technical Details
+
+**Affected files:**
+- `src/pages/InventoryListPage.tsx:304`
+- `src/pages/InventoryListPage.tsx:336`
+
+## Resources
+
+- Review branch: `codex/invoice-pricing-parity-weight-edit`
+
+## Acceptance Criteria
+
+- [ ] Repeated invoice rows with the same normalized name do not create duplicate products.
+- [ ] Repeated invoice rows produce one product with cumulative stock movements.
+- [ ] Manual test with missing-barcode repeated rows passes.
+
+## Work Log
+
+### 2026-02-11 - Code Review Discovery
+
+**By:** Codex
+
+**Actions:**
+- Reviewed invoice import matching flow.
+- Traced control flow for same-batch repeated names.
+- Confirmed map is not updated after creation.
+
+**Learnings:**
+- Name-based matching is present but not stateful across the current import loop.
+
+## Notes
+
+- This is merge-blocking for invoice imports where suppliers split the same product across multiple lines.
+
+### 2026-02-11 - Fix Implemented
+
+**By:** Codex
+
+**Actions:**
+- Updated invoice import flow to maintain `normalizedNameMap` during processing.
+- Added map updates when matching existing products and after creating new products.
+- Prevented same-batch duplicate creates for repeated normalized names.
+
+**Learnings:**
+- Stateful in-memory matching is enough to fix same-invoice duplicate creation in frontend-led import.

--- a/todos/012-complete-p2-invoice-import-partial-write-inconsistency.md
+++ b/todos/012-complete-p2-invoice-import-partial-write-inconsistency.md
@@ -1,0 +1,105 @@
+---
+status: complete
+priority: p2
+issue_id: "012"
+tags: [code-review, reliability, invoice-import]
+dependencies: []
+---
+
+# Invoice import can report failure after successful product write
+
+Create/update and stock movement are executed in the same try/catch without compensation. If stock movement fails, the product write already committed, but the row is reported as failed.
+
+## Problem Statement
+
+A row can be partially applied: product pricing updates persist, stock movement fails, and UI reports an error. Retrying import can then re-apply product updates and potentially over-count stock if the retry partially succeeds.
+
+## Findings
+
+- `src/pages/InventoryListPage.tsx:323` updates existing product before stock movement.
+- `src/pages/InventoryListPage.tsx:336` creates new product before stock movement.
+- `src/pages/InventoryListPage.tsx:332` / `src/pages/InventoryListPage.tsx:349` add stock movement after product write.
+- Any stock movement exception is caught at row level and counted as a failed row (`src/pages/InventoryListPage.tsx:355`), even though earlier write already succeeded.
+
+## Proposed Solutions
+
+### Option 1: Treat stock-movement failure as partial success with explicit warning
+
+Track separate statuses (`product_written`, `stock_failed`) and show explicit remediation action.
+
+**Pros:**
+- Honest UX about partial commit.
+- Minimal implementation effort.
+
+**Cons:**
+- Does not make operation atomic.
+
+**Effort:** Small
+
+**Risk:** Low
+
+---
+
+### Option 2: Move row apply logic to backend transaction
+
+Use backend `import` endpoint with idempotency and DB transaction semantics.
+
+**Pros:**
+- Strong consistency and safer retries.
+
+**Cons:**
+- Larger scope and backend dependency.
+
+**Effort:** Medium/Large
+
+**Risk:** Medium
+
+## Recommended Action
+
+
+## Technical Details
+
+**Affected files:**
+- `src/pages/InventoryListPage.tsx:323`
+- `src/pages/InventoryListPage.tsx:332`
+- `src/pages/InventoryListPage.tsx:349`
+- `src/pages/InventoryListPage.tsx:355`
+
+## Resources
+
+- Review branch: `codex/invoice-pricing-parity-weight-edit`
+
+## Acceptance Criteria
+
+- [ ] Import result distinguishes full success from partial success.
+- [ ] Retry guidance prevents accidental double-application.
+- [ ] Failure messaging includes whether product record was already written.
+
+## Work Log
+
+### 2026-02-11 - Code Review Discovery
+
+**By:** Codex
+
+**Actions:**
+- Reviewed row execution order for invoice import.
+- Validated failure handling around create/update + stock movement.
+
+**Learnings:**
+- Current control flow favors best-effort writes but surfaces binary row status.
+
+## Notes
+
+- This is important for operational trust and support debugging.
+
+### 2026-02-11 - Fix Implemented
+
+**By:** Codex
+
+**Actions:**
+- Split product write and stock movement failure handling for invoice rows.
+- Added partial-result tracking when stock movement fails after successful product write.
+- Updated user toast summary to include partially imported rows and keep warnings explicit.
+
+**Learnings:**
+- Best-effort writes need explicit partial-state UX to avoid misleading retry behavior.

--- a/todos/013-complete-p2-mixed-import-source-routing.md
+++ b/todos/013-complete-p2-mixed-import-source-routing.md
@@ -1,0 +1,102 @@
+---
+status: complete
+priority: p2
+issue_id: "013"
+tags: [code-review, quality, import]
+dependencies: []
+---
+
+# Mixed-source imports are routed through invoice path
+
+Import routing uses `some()` to decide mode. If any row has `importSource === 'invoice'`, all rows are processed with invoice logic.
+
+## Problem Statement
+
+The handler currently assumes the batch is homogeneous. A mixed payload (invoice + xlsx rows) can route xlsx rows through invoice update/create semantics unexpectedly.
+
+## Findings
+
+- `src/pages/InventoryListPage.tsx:302` sets `isInvoiceImport` with `some(...)`.
+- `src/pages/InventoryListPage.tsx:303` branches the full batch into invoice path.
+- No per-row source guard exists inside the loop.
+
+## Proposed Solutions
+
+### Option 1: Enforce homogeneous batches at runtime (recommended)
+
+Validate all rows share the same `importSource`; throw a clear error otherwise.
+
+**Pros:**
+- Small change.
+- Prevents silent misrouting.
+
+**Cons:**
+- Rejects mixed batches instead of handling them.
+
+**Effort:** Small
+
+**Risk:** Low
+
+---
+
+### Option 2: Split and process by source
+
+Partition into invoice/xlsx sub-batches and run each path explicitly.
+
+**Pros:**
+- Fully robust to mixed payloads.
+
+**Cons:**
+- More code and duplicated summary aggregation.
+
+**Effort:** Medium
+
+**Risk:** Medium
+
+## Recommended Action
+
+
+## Technical Details
+
+**Affected files:**
+- `src/pages/InventoryListPage.tsx:302`
+- `src/pages/InventoryListPage.tsx:303`
+
+## Resources
+
+- Review branch: `codex/invoice-pricing-parity-weight-edit`
+
+## Acceptance Criteria
+
+- [ ] Mixed-source payload is either rejected clearly or handled by explicit partitioning.
+- [ ] Existing pure-xlsx and pure-invoice flows keep current behavior.
+- [ ] Import summary remains accurate after source routing changes.
+
+## Work Log
+
+### 2026-02-11 - Code Review Discovery
+
+**By:** Codex
+
+**Actions:**
+- Reviewed import mode routing condition.
+- Validated that branch selection is batch-wide.
+
+**Learnings:**
+- Current function contract implicitly expects homogeneous input but does not enforce it.
+
+## Notes
+
+- Lower urgency than data duplication, but worth fixing for robustness.
+
+### 2026-02-11 - Fix Implemented
+
+**By:** Codex
+
+**Actions:**
+- Added strict source-homogeneity validation at import start.
+- Mixed-source batches now fail fast with clear error toast and no writes.
+- Kept existing behavior for pure invoice and pure xlsx batches.
+
+**Learnings:**
+- Batch-level guard is the smallest safe fix for routing ambiguity.


### PR DESCRIPTION
## Summary

This PR completes the frontend side of invoice-import pricing parity and reliability so invoice flow behaves like the established Excel flow while keeping owner effort low.

The primary user-facing problem was that invoice import did not consistently apply transport-aware pricing outputs, could create duplicate products when repeated invoice rows had no barcode, and could report a row as failed even after product data had already been written.

## Issue and User Impact

Store owners rely on importing invoices to avoid manual Excel work. In the current behavior, three issues created risk:

1. Same-batch duplicate creation: repeated invoice lines with the same product name and missing barcode could create multiple product records.
2. Partial write ambiguity: product create/update could succeed while stock movement failed, but the row was shown as fully failed.
3. Mixed payload routing ambiguity: if a mixed source payload ever reached the handler, all rows could be routed through invoice logic.

These issues could lead to inventory fragmentation, confusing retry behavior, and harder troubleshooting.

## Root Cause

- Name matching map was initialized from existing inventory but not updated after newly created rows during the same import batch.
- Product writes and stock writes were executed in one try/catch path with no explicit partial outcome model.
- Import mode selection used `some()` and assumed homogeneous source batches without enforcing it.

## What Changed

### Frontend invoice pricing/import flow

- Added FastAPI preview client for pricing contract:
  - `src/lib/invoiceImportApi.ts`
- Added weight parsing helper from size token prefixes in product names:
  - `src/lib/invoicePricing.ts`
- Updated OCR mapping/types to support `row_id` and `weight_kg_candidate`:
  - `src/lib/invoiceOCR.ts`
- Extended imported product metadata for invoice flow:
  - `src/lib/xlsx/index.ts`
- Updated invoice upload dialog to:
  - prefill/edit weight per row,
  - block import if weight is missing,
  - call `/invoice/preview-pricing`,
  - map backend computed prices (`base_price_eur`, `price_50`, `price_70`, `price_100`) into import payload.
  - file: `src/components/invoice/InvoiceUploadDialog.tsx`

### Reliability fixes in import executor

- Enforced source homogeneity (invoice vs xlsx) at batch start; mixed source now fails fast with clear message.
- Updated normalized name map during invoice processing so newly created products are immediately matchable in the same batch.
- Added explicit partial outcome handling for stock movement failures after successful product writes.
- Surfaced partial rows in warning toast under “Partially imported products”.
- file: `src/pages/InventoryListPage.tsx`

### Process documentation and review artifacts

- Brainstorm, plan, and API contract docs added under `docs/`.
- Review findings captured and marked complete in `todos/011-013`.

## Validation

- `pnpm -s build` (pass)
- `pnpm -s eslint src/pages/InventoryListPage.tsx` (pass)

## Notes

- Current implementation keeps persistence in frontend (Supabase path) per MVP scope decision.
- Backend `/invoice/import` idempotency/transaction semantics are intentionally deferred in this iteration.
