### PR TITLE
[codex] Invoice extract cache observability

### DIFF
--- a/api/extract-invoice.ts
+++ b/api/extract-invoice.ts
@@ -3,6 +3,10 @@ import { createClient } from '@supabase/supabase-js';
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
+function isTruthy(value: string | undefined): boolean {
+  return !!value && ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
 function resolveExtractUrl(): string | null {
   const configuredBaseUrl = process.env.INVOICE_API_URL || process.env.VITE_INVOICE_API_URL;
   if (!configuredBaseUrl) {
@@ -116,6 +120,39 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     res.status(upstreamResponse.status);
     res.setHeader('Content-Type', upstreamContentType);
+
+    // Forward a small set of debugging headers (useful for cache hit/miss verification).
+    // Keep this allowlist tight to avoid leaking unexpected upstream headers.
+    const passthroughHeaders: string[] = [
+      'x-extract-cache',
+      'x-instance-id',
+      'x-process-id',
+      'x-cache',
+      'x-request-id',
+      'x-upstream-request-id',
+      'x-render-service',
+      'x-render-instance',
+    ];
+
+    // Debug-only: file hash can act as a stable invoice identifier. Do not expose by default.
+    if (isTruthy(process.env.INVOICE_PROXY_DEBUG_HEADERS)) {
+      passthroughHeaders.push('x-extract-file-hash');
+    }
+
+    passthroughHeaders.forEach((header) => {
+      const value = upstreamResponse.headers.get(header);
+      if (value) {
+        res.setHeader(header, value);
+      }
+    });
+
+    // If this endpoint is ever called cross-origin (uncommon), allow browser JS to read debug headers.
+    // Same-origin calls can read headers without this.
+    res.setHeader(
+      'Access-Control-Expose-Headers',
+      passthroughHeaders.join(', ')
+    );
+
     return res.send(responseText);
   } catch (error) {
     console.error('Invoice proxy error:', error);

--- a/docs/solutions/integration-issues/missing-extract-cache-headers-InvoiceOCR-20260213.md
+++ b/docs/solutions/integration-issues/missing-extract-cache-headers-InvoiceOCR-20260213.md
@@ -1,0 +1,106 @@
+---
+module: InvoiceOCR
+date: 2026-02-13
+problem_type: integration_issue
+component: api_client
+symptoms:
+  - "Repeated POST /extract calls stay slow and never show x-extract-cache=hit"
+  - "Response headers like x-extract-cache/x-instance-id/x-process-id missing in curl/browser"
+  - "Frontend proxy path (/api/extract-invoice) hides upstream debug headers"
+root_cause: config_error
+resolution_type: code_fix
+severity: medium
+tags: [invoice-ocr, fastapi, headers, cache, vercel, proxy, debug]
+related_github_issue: null
+commit: null
+---
+
+# Problem Description
+
+Invoice extraction caching was implemented on the FastAPI `/extract` endpoint, but the frontend still observed 60-70s requests and could not see cache observability headers. This made it impossible to confirm cache hits, multi-worker routing, or whether the running backend included the header changes.
+
+# Symptoms
+
+- Repeating the same PDF upload to `POST /extract` remained slow (no clear warm/hit behavior).
+- `x-extract-cache` and related headers did not appear in `curl -D -` output.
+- When using the browser path (`/api/extract-invoice`), upstream headers were not visible/forwarded.
+
+# Root Cause Analysis
+
+This was a combination of integration and environment issues:
+
+1. **Backend process mismatch:** The API server was started without `PYTHONPATH=src`, so Python imported an older installed `invproc` package (without the new headers/caching behavior) instead of the repo source tree.
+2. **Proxy header passthrough:** The Vercel proxy endpoint did not forward custom cache/debug headers by default.
+3. **Frontend header visibility:** The XHR upload path originally discarded response headers (only constructing a `Response` from `responseText`).
+
+# Solution
+
+## 1) Start the InvoiceProcessing API from repo source (not site-packages)
+
+Verify which module path is being imported:
+
+```bash
+PYTHONPATH=src python3 -c "import invproc.api; print(invproc.api.__file__)"
+```
+
+It must point into your repo `src/invproc/api.py`, not `site-packages`.
+
+Start the API with `PYTHONPATH=src` and cache enabled:
+
+```bash
+PYTHONPATH=src \
+EXTRACT_CACHE_ENABLED=true \
+API_KEYS=dev-key-12345 \
+API_HOST=127.0.0.1 \
+API_PORT=8000 \
+python -m invproc --mode api
+```
+
+Verify headers:
+
+```bash
+curl -sS -D - -o /dev/null \
+  -H 'X-API-Key: dev-key-12345' \
+  -F 'file=@public/test-invoices/invoice-test.pdf;type=application/pdf' \
+  http://127.0.0.1:8000/extract | rg -i 'x-extract-cache|x-instance-id|x-process-id|^http/'
+```
+
+## 2) Forward cache/process headers through the Vercel proxy
+
+Updated `/api/extract-invoice` to forward the upstream observability headers:
+
+- `x-extract-cache`
+- `x-instance-id`
+- `x-process-id`
+
+Debug-only (opt-in):
+
+- `x-extract-file-hash` only when `INVOICE_PROXY_DEBUG_HEADERS=true`
+
+## 3) Preserve response headers from the XHR upload response
+
+The invoice upload uses `XMLHttpRequest` for upload progress. We parse `xhr.getAllResponseHeaders()` and attach them to the constructed `Response` so `response.headers.get(...)` works.
+
+## 4) Avoid leaking stable document identifiers in production
+
+`x-extract-file-hash` can act as a stable invoice identifier. Best practice is:
+
+- Do not forward it by default from the proxy
+- Do not log it client-side by default
+- Only enable in local/dev debugging
+
+# Files Changed
+
+- `api/extract-invoice.ts`
+- `src/lib/invoiceOCR.ts`
+
+# Prevention
+
+- Always verify your running backend is the repo code: `PYTHONPATH=src python3 -c "import invproc.api; print(invproc.api.__file__)"`
+- For cache diagnosis, rely on `x-extract-cache`, `x-instance-id`, `x-process-id` (and avoid file hashes unless explicitly debugging).
+- Keep the multipart field name consistent with FastAPI: `file` (some servers will 422 on unexpected field names).
+
+# Related Issues
+
+- See also: `docs/solutions/integration-issues/invoice-proxy-security-hardening-InvoiceOCRProxy-20260210.md`
+

--- a/src/lib/invoiceOCR.ts
+++ b/src/lib/invoiceOCR.ts
@@ -191,6 +191,7 @@ function isValidNumber(value: unknown): value is number {
 async function uploadWithProgress(
   url: string,
   file: File,
+  fileFieldName: string,
   headers: Record<string, string>,
   onProgress?: (progress: number) => void
 ): Promise<Response> {
@@ -198,11 +199,9 @@ async function uploadWithProgress(
     const xhr = new XMLHttpRequest();
     const formData = new FormData();
 
-    // Backward/forward compatibility for backend field naming.
-    // FastAPI may expect one of these names depending on version.
-    formData.append('file', file);
-    formData.append('invoice', file);
-    formData.append('invoice_file', file);
+    // IMPORTANT: only append the file once. Appending under multiple keys
+    // duplicates bytes in the multipart payload (3x upload time/size).
+    formData.append(fileFieldName, file);
 
     // Track actual upload progress (40% → 70%)
     xhr.upload.addEventListener('progress', (e) => {
@@ -215,7 +214,29 @@ async function uploadWithProgress(
     xhr.onload = () => {
       // Upload complete, server processing: 70% → 90%
       onProgress?.(90);
-      resolve(new Response(xhr.responseText, { status: xhr.status }));
+      const responseHeaders = new Headers();
+      const rawHeaders = xhr.getAllResponseHeaders();
+      if (rawHeaders) {
+        rawHeaders
+          .trim()
+          .split(/[\r\n]+/)
+          .forEach((line) => {
+            const idx = line.indexOf(':');
+            if (idx === -1) return;
+            const key = line.slice(0, idx).trim();
+            const value = line.slice(idx + 1).trim();
+            if (!key) return;
+            responseHeaders.append(key, value);
+          });
+      }
+
+      resolve(
+        new Response(xhr.responseText, {
+          status: xhr.status,
+          statusText: xhr.statusText,
+          headers: responseHeaders,
+        })
+      );
     };
 
     xhr.onerror = () => {
@@ -355,7 +376,10 @@ export async function extractInvoiceData(
     // Call FastAPI /extract endpoint with real upload progress
     let response: Response;
     try {
-      response = await uploadWithProgress(extractUrl, file, headers, onProgress);
+      const configuredFieldName = (import.meta.env.VITE_INVOICE_UPLOAD_FIELD_NAME as string | undefined)?.trim();
+      const fileFieldName = configuredFieldName || 'file';
+      // Use guarded callback in the XHR event handlers too.
+      response = await uploadWithProgress(extractUrl, file, fileFieldName, headers, safeProgress);
     } catch (error) {
       // Handle timeout errors (both AbortError and explicit timeout message)
       if (error instanceof Error && (error.name === 'AbortError' || error.message === 'Upload timed out')) {
@@ -409,6 +433,34 @@ export async function extractInvoiceData(
         success: false,
         error: 'Unauthorized request. Please check your server-side invoice API configuration.',
       };
+    }
+
+    // Cache/debug observability headers (if backend supports them).
+    // Useful to diagnose "no speedup" reports (cache disabled, misses, or multi-worker).
+    try {
+      const extractCache = response.headers.get('x-extract-cache') || undefined;
+      const instanceId = response.headers.get('x-instance-id') || undefined;
+      const processId = response.headers.get('x-process-id') || undefined;
+      // Treat file hash as sensitive debug-only metadata. Do not log by default.
+      const debugHeadersEnabled =
+        import.meta.env.DEV ||
+        String(import.meta.env.VITE_INVOICE_DEBUG_HEADERS || '')
+          .trim()
+          .toLowerCase() === 'true';
+      const fileHash = debugHeadersEnabled ? response.headers.get('x-extract-file-hash') || undefined : undefined;
+
+      if (extractCache || instanceId || processId || fileHash) {
+        logger.info('Invoice extract observability', {
+          url: extractUrl,
+          status: response.status,
+          extractCache,
+          instanceId,
+          processId,
+          ...(fileHash ? { fileHash } : {}),
+        });
+      }
+    } catch {
+      // If CORS blocks header access in direct-dev mode, ignore.
     }
 
     // Handle client errors (400, 422) with detailed backend message when available

--- a/todos/025-complete-p2-safe-progress-wrapper-in-xhr-upload.md
+++ b/todos/025-complete-p2-safe-progress-wrapper-in-xhr-upload.md
@@ -1,0 +1,98 @@
+---
+status: complete
+priority: p2
+issue_id: "025"
+tags: [code-review, invoice-ocr, frontend, reliability]
+dependencies: []
+---
+
+# Use Safe Progress Wrapper For XHR Upload Callbacks
+
+The invoice OCR client defines a `safeProgress()` wrapper to guard against exceptions from the UI progress callback, but the XHR upload path still calls the raw callback directly.
+
+## Problem Statement
+
+Progress callbacks are invoked from XHR event handlers. If the callback throws (or gets replaced with something that can throw), it can cause unpredictable behavior during uploads and undermine the purpose of `safeProgress()`.
+
+## Findings
+
+- `src/lib/invoiceOCR.ts:281-291` defines `safeProgress()`.
+- `src/lib/invoiceOCR.ts:206-216` calls `onProgress?.(...)` directly inside XHR progress handlers.
+- `src/lib/invoiceOCR.ts:381` passes the raw `onProgress` to `uploadWithProgress(...)` instead of `safeProgress`.
+
+## Proposed Solutions
+
+### Option 1: Pass `safeProgress` Into `uploadWithProgress` (Recommended)
+
+**Approach:** Pass `safeProgress` to `uploadWithProgress(...)` and use that function for all progress updates inside the XHR helper.
+
+**Pros:**
+- Matches the intent of the existing wrapper.
+- Prevents unexpected exceptions from breaking upload flow.
+- Minimal code change.
+
+**Cons:**
+- Slight indirection (progress behavior is now always guarded).
+
+**Effort:** 10-15 minutes
+
+**Risk:** Low
+
+---
+
+### Option 2: Wrap Internally In `uploadWithProgress`
+
+**Approach:** Keep passing `onProgress`, but wrap calls inside `uploadWithProgress` with `try/catch`.
+
+**Pros:**
+- Protects progress path without changing call sites.
+
+**Cons:**
+- Duplicates logic; now there are two "safe progress" implementations.
+
+**Effort:** 10-15 minutes
+
+**Risk:** Low
+
+## Recommended Action
+
+**To be filled during triage.**
+
+## Technical Details
+
+**Affected files:**
+- `src/lib/invoiceOCR.ts`
+
+## Resources
+
+- Related: `docs/solutions/performance-issues/invoice-ocr-timeout-and-progress-tracking.md`
+
+## Acceptance Criteria
+
+- [ ] All progress updates in XHR upload path are guarded against callback exceptions.
+- [ ] Unit tests still pass (`pnpm test:unit`).
+
+## Work Log
+
+### 2026-02-13 - Initial Discovery
+
+**By:** Codex
+
+**Actions:**
+- Noted mismatch between `safeProgress()` definition and raw callback usage in XHR upload helper.
+
+**Learnings:**
+- The helper path is still calling `onProgress` directly from event handlers.
+
+---
+
+### 2026-02-13 - Fix Implemented
+
+**By:** Codex
+
+**Actions:**
+- Updated `extractInvoiceData()` to pass `safeProgress` into `uploadWithProgress()` so XHR event callbacks are guarded too.
+- Ran `pnpm lint` and `pnpm test:unit` (pass).
+
+**Learnings:**
+- Guarding the callback at the boundary (XHR helper) keeps behavior stable even if UI code changes.

--- a/todos/026-complete-p2-gate-or-redact-extract-file-hash-observability.md
+++ b/todos/026-complete-p2-gate-or-redact-extract-file-hash-observability.md
@@ -1,0 +1,106 @@
+---
+status: complete
+priority: p2
+issue_id: "026"
+tags: [code-review, invoice-ocr, security, observability]
+dependencies: []
+---
+
+# Gate Or Redact `x-extract-file-hash` Observability
+
+We currently forward and log cache/debug headers from the invoice extraction service. This is useful for diagnosing cache hit rates and multi-worker behavior, but `x-extract-file-hash` can act as a stable identifier for a specific invoice PDF.
+
+## Problem Statement
+
+Even a truncated file hash can become a correlation identifier for sensitive documents. If enabled in production by mistake, it can leak into:
+
+- Browser-accessible headers
+- Client logs (console / log drain)
+- Proxies and edge logs
+
+## Findings
+
+- Proxy forwards `x-extract-file-hash` when present:
+  - `api/extract-invoice.ts:122-146`
+- Client logs `x-extract-file-hash` when present:
+  - `src/lib/invoiceOCR.ts:437-456`
+- Backend only sets the header when `EXTRACT_CACHE_DEBUG_HEADERS=true` (expected), but the frontend/proxy should still be defensive against accidental enablement.
+
+## Proposed Solutions
+
+### Option 1: Do Not Forward Or Log `x-extract-file-hash` By Default (Recommended)
+
+**Approach:**
+- Remove `x-extract-file-hash` from the default proxy allowlist.
+- Do not log `fileHash` client-side unless `import.meta.env.DEV` or an explicit opt-in env var is set.
+- Keep forwarding/logging `x-extract-cache`, `x-instance-id`, `x-process-id`.
+
+**Pros:**
+- Stronger privacy posture by default.
+- Still preserves the most important diagnostic fields for cache vs multi-worker.
+
+**Cons:**
+- Debugging "cache key mismatch" is slightly harder without explicit opt-in.
+
+**Effort:** 20-30 minutes
+
+**Risk:** Low
+
+---
+
+### Option 2: Keep Forwarding, But Redact
+
+**Approach:** Forward/log only a shorter prefix (e.g., first 6 chars) or hash the hash again before exposing.
+
+**Pros:**
+- Still supports correlation in local debugging.
+
+**Cons:**
+- Still a stable identifier; redaction lowers but does not remove the risk.
+
+**Effort:** 20-30 minutes
+
+**Risk:** Medium
+
+## Recommended Action
+
+**To be filled during triage.**
+
+## Technical Details
+
+**Affected files:**
+- `api/extract-invoice.ts`
+- `src/lib/invoiceOCR.ts`
+
+## Acceptance Criteria
+
+- [ ] Production default does not expose `x-extract-file-hash` to browsers.
+- [ ] Cache/multi-worker diagnosis still works via `x-extract-cache`, `x-instance-id`, `x-process-id`.
+- [ ] Unit tests pass (`pnpm test:unit`).
+
+## Work Log
+
+### 2026-02-13 - Initial Discovery
+
+**By:** Codex
+
+**Actions:**
+- Identified that `x-extract-file-hash` is forwarded by the proxy and logged client-side when present.
+
+**Learnings:**
+- The backend intends this header to be debug-only, but frontend/proxy should be defensive.
+
+---
+
+### 2026-02-13 - Fix Implemented
+
+**By:** Codex
+
+**Actions:**
+- Removed `x-extract-file-hash` from the default proxy passthrough allowlist; only forward when `INVOICE_PROXY_DEBUG_HEADERS=true`.
+- Kept forwarding `x-extract-cache`, `x-instance-id`, `x-process-id` for production-safe diagnosis.
+- Updated client-side logging to treat `x-extract-file-hash` as debug-only; it is only logged in dev or when `VITE_INVOICE_DEBUG_HEADERS=true`.
+- Ran `pnpm lint` and `pnpm test:unit` (pass).
+
+**Learnings:**
+- Cache/worker diagnosis doesn’t require a stable document identifier; keep that strictly opt-in.


### PR DESCRIPTION
## Problem
Invoice extraction caching and observability headers exist on the FastAPI `/extract` endpoint, but the frontend couldn’t reliably verify whether requests were:

- cache `hit` vs `miss`
- routed to the same worker/process vs round-robin
- running the expected backend build

Additionally, the frontend upload path had a couple of issues that could mask backend improvements:

- The PDF was previously appended multiple times to `FormData` (duplicating bytes in the multipart upload).
- The XHR upload path discarded response headers, so browser code couldn’t read `x-extract-cache` even when the backend set it.

## Changes
### Frontend (`src/lib/invoiceOCR.ts`)
- Upload the invoice PDF only once (default multipart field name is `file`).
- Preserve response headers from `XMLHttpRequest` (`getAllResponseHeaders()`), so code can read observability headers.
- Route XHR progress updates through the existing `safeProgress()` wrapper.
- Log cache/instance/process headers when present:
  - `x-extract-cache`
  - `x-instance-id`
  - `x-process-id`
- Treat `x-extract-file-hash` as debug-only:
  - only read/log in dev or with `VITE_INVOICE_DEBUG_HEADERS=true`.

### Proxy (`api/extract-invoice.ts`)
- Forward upstream observability headers through `/api/extract-invoice`:
  - `x-extract-cache`, `x-instance-id`, `x-process-id`
- Do not forward `x-extract-file-hash` by default (it can act as a stable invoice identifier).
  - opt-in with `INVOICE_PROXY_DEBUG_HEADERS=true`.

### Documentation
- Added a troubleshooting doc describing the root causes and verification steps:
  - `docs/solutions/integration-issues/missing-extract-cache-headers-InvoiceOCR-20260213.md`

## How To Verify
1. Upload the same PDF twice.
2. Check response headers in DevTools Network (or logs):
   - `x-extract-cache` should switch from `miss` to `hit` (if backend cache is enabled and worker is stable).
   - `x-process-id` should remain stable between calls if you are hitting the same worker.

Optional debug:
- Set `INVOICE_PROXY_DEBUG_HEADERS=true` to forward `x-extract-file-hash`.
- Set `VITE_INVOICE_DEBUG_HEADERS=true` to log it in the browser.

## Tests
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:e2e`
- `pnpm validate-docs`
